### PR TITLE
[2.x] Improve method naming

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosStatic } from 'axios';
 import createAuthRefreshInterceptor, {
-    mergeConfigs,
+    mergeOptions,
     shouldInterceptError,
     createRefreshCall,
     createRequestQueueInterceptor,
@@ -58,19 +58,19 @@ describe('Merges configs', () => {
     it('master and slave are the same', () => {
         const master: AxiosAuthRefreshOptions = { statusCodes: [ 204 ] };
         const slave: AxiosAuthRefreshOptions = { statusCodes: [ 204 ] };
-        expect(mergeConfigs(master, slave)).toEqual({ statusCodes: [ 204 ] });
+        expect(mergeOptions(slave, master)).toEqual({ statusCodes: [ 204 ] });
     });
 
     it('master is different than the slave', () => {
         const master: AxiosAuthRefreshOptions = { statusCodes: [ 302 ] };
         const slave: AxiosAuthRefreshOptions = { statusCodes: [ 204 ] };
-        expect(mergeConfigs(master, slave)).toEqual({ statusCodes: [ 302 ] });
+        expect(mergeOptions(slave, master)).toEqual({ statusCodes: [ 302 ] });
     });
 
     it('master is empty', () => {
         const master: AxiosAuthRefreshOptions = {};
         const slave: AxiosAuthRefreshOptions = { statusCodes: [ 204 ] };
-        expect(mergeConfigs(master, slave)).toEqual({ statusCodes: [ 204 ] });
+        expect(mergeOptions(slave, master)).toEqual({ statusCodes: [ 204 ] });
     });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export interface AxiosAuthRefreshRequestConfig extends AxiosRequestConfig {
 
 // Constants
 
-const defaults: AxiosAuthRefreshOptions = {
+const defaultOptions: AxiosAuthRefreshOptions = {
     statusCodes: [ 401 ],
     instance: undefined,
     skipWhileRefreshing: true
@@ -57,8 +57,8 @@ export default function createAuthRefreshInterceptor(
 
     return instance.interceptors.response.use((res: AxiosResponse) => res, (error: any) => {
 
-        // Rewrite default config
-        options = mergeConfigs(options, defaults);
+        // Rewrite default options
+        options = mergeOptions(defaultOptions, options);
 
         // Reject promise if the error status is not in options.ports
         if (!shouldInterceptError(error, options, instance, cache)) {
@@ -90,9 +90,9 @@ export default function createAuthRefreshInterceptor(
 }
 
 /**
- * Merges two config objects (master rewrites slave)
+ * Merges two options objects (master rewrites slave)
  */
-export function mergeConfigs(master: AxiosAuthRefreshOptions, def: AxiosAuthRefreshOptions): AxiosAuthRefreshOptions {
+export function mergeOptions(def: AxiosAuthRefreshOptions, master: AxiosAuthRefreshOptions): AxiosAuthRefreshOptions {
     return { ...def, ...master };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,8 +92,8 @@ export default function createAuthRefreshInterceptor(
 /**
  * Merges two options objects (master rewrites slave)
  */
-export function mergeOptions(def: AxiosAuthRefreshOptions, master: AxiosAuthRefreshOptions): AxiosAuthRefreshOptions {
-    return { ...def, ...master };
+export function mergeOptions(slave: AxiosAuthRefreshOptions, master: AxiosAuthRefreshOptions): AxiosAuthRefreshOptions {
+    return { ...slave, ...master };
 }
 
 /**


### PR DESCRIPTION
This PR include following improvements:
- `defaults` constant renamed to `defaultOptions` to make name more intuitive.
- `mergeConfigs` method renamed to `mergeOptions` because we are merging options and not configs.
- `mergeConfigs` method properties are swapped their places, to make it more obvious that second argument will overwrite first one.
- `mergeConfigs` method property `def` renamed to `slave` because it named so in DocBlock and second property named `master`.