### PR TITLE
[2.x] Replace magic typecasting with more obvious

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,7 @@ export function shouldInterceptError(
 ): boolean {
     return error
         && !(error.config && error.config.skipAuthRefresh)
-        && error.response && options.statusCodes.includes(+error.response.status)
+        && error.response && options.statusCodes.includes(parseInt(error.response.status))
         && !(options.skipWhileRefreshing && cache.skipInstances.includes(instance));
 }
 


### PR DESCRIPTION
Since this package is using TypeScript I think it will be better to replace `+error.response.status` magic typecasting with more strict one `parseInt(error.response.status)`.