### PR TITLE
[2.x] Improve shouldInterceptError method readability

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -106,10 +106,19 @@ export function shouldInterceptError(
     instance: AxiosInstance,
     cache: AxiosAuthRefreshCache
 ): boolean {
-    return error
-        && !(error.config && error.config.skipAuthRefresh)
-        && error.response && options.statusCodes.includes(+error.response.status)
-        && !(options.skipWhileRefreshing && cache.skipInstances.includes(instance));
+    if (!error) {
+        return false;
+    }
+
+    if (error.config && error.config.skipAuthRefresh) {
+        return false;
+    }
+
+    if (!error.response || !options.statusCodes.includes(parseInt(error.response.status))) {
+        return false;
+    }
+
+    return !options.skipWhileRefreshing || !cache.skipInstances.includes(instance);
 }
 
 /**


### PR DESCRIPTION
This PR breaks down all conditionals to separate blocks to improve readability and easier maintenance. Maybe you'll improve method with any other way, but it's hard to read and understand now.