### PR TITLE
Update mergeOptions parameter naming

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -58,22 +58,22 @@ const sleep = (ms) => {
 
 describe('Merges configs', () => {
 
-    it('master and slave are the same', () => {
-        const master: AxiosAuthRefreshOptions = { statusCodes: [ 204 ] };
-        const slave: AxiosAuthRefreshOptions = { statusCodes: [ 204 ] };
-        expect(mergeOptions(slave, master)).toEqual({ statusCodes: [ 204 ] });
+    it('source and target are the same', () => {
+        const source: AxiosAuthRefreshOptions = { statusCodes: [ 204 ] };
+        const target: AxiosAuthRefreshOptions = { statusCodes: [ 204 ] };
+        expect(mergeOptions(target, source)).toEqual({ statusCodes: [ 204 ] });
     });
 
-    it('master is different than the slave', () => {
-        const master: AxiosAuthRefreshOptions = { statusCodes: [ 302 ] };
-        const slave: AxiosAuthRefreshOptions = { statusCodes: [ 204 ] };
-        expect(mergeOptions(slave, master)).toEqual({ statusCodes: [ 302 ] });
+    it('source is different than the target', () => {
+        const source: AxiosAuthRefreshOptions = { statusCodes: [ 302 ] };
+        const target: AxiosAuthRefreshOptions = { statusCodes: [ 204 ] };
+        expect(mergeOptions(target, source)).toEqual({ statusCodes: [ 302 ] });
     });
 
-    it('master is empty', () => {
-        const master: AxiosAuthRefreshOptions = {};
-        const slave: AxiosAuthRefreshOptions = { statusCodes: [ 204 ] };
-        expect(mergeOptions(slave, master)).toEqual({ statusCodes: [ 204 ] });
+    it('source is empty', () => {
+        const source: AxiosAuthRefreshOptions = {};
+        const target: AxiosAuthRefreshOptions = { statusCodes: [ 204 ] };
+        expect(mergeOptions(target, source)).toEqual({ statusCodes: [ 204 ] });
     });
 });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,15 +13,15 @@ export const defaultOptions: AxiosAuthRefreshOptions = {
 };
 
 /**
- * Merges two options objects (master rewrites slave).
+ * Merges two options objects (source rewrites target).
  *
  * @return {AxiosAuthRefreshOptions}
  */
 export function mergeOptions(
-    slave: AxiosAuthRefreshOptions,
-    master: AxiosAuthRefreshOptions,
+    target: AxiosAuthRefreshOptions,
+    source: AxiosAuthRefreshOptions,
 ): AxiosAuthRefreshOptions {
-  return { ...slave, ...master };
+  return { ...target, ...source };
 }
 
 /**


### PR DESCRIPTION
The parameter names used in mergeOptions aren't accurate for what the function does, and, are words we should move away from as a society in general.

Tests run and pass - should have no impact on any users of this code.