### PR TITLE
skip request cache with skipAuthRefresh tag

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,10 @@ export interface AxiosAuthRefreshCache {
   requestQueueInterceptorId: number|undefined;
 }
 
+export interface CustomAxiosRequestConfig extends AxiosRequestConfig {
+    skipAuthRefresh?: boolean
+}
+
 export const defaultOptions: AxiosAuthRefreshOptions = {
   statusCodes: [ 401 ],
   pauseInstanceWhileRefreshing: false,
@@ -86,8 +90,8 @@ export function createRequestQueueInterceptor(
     options: AxiosAuthRefreshOptions,
 ): number {
   if (typeof cache.requestQueueInterceptorId === 'undefined') {
-    cache.requestQueueInterceptorId = instance.interceptors.request.use((request) => {
-      if(request.data && request.data.skipAuthRefresh)
+    cache.requestQueueInterceptorId = instance.interceptors.request.use((request: CustomAxiosRequestConfig) => {
+      if(request?.skipAuthRefresh)
         return request
       return cache.refreshCall
           .catch(() => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,6 +87,8 @@ export function createRequestQueueInterceptor(
 ): number {
   if (typeof cache.requestQueueInterceptorId === 'undefined') {
     cache.requestQueueInterceptorId = instance.interceptors.request.use((request) => {
+      if(request.data.skipAuthRefresh)
+        return request
       return cache.refreshCall
           .catch(() => {
             throw new axios.Cancel('Request call failed');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,7 +87,7 @@ export function createRequestQueueInterceptor(
 ): number {
   if (typeof cache.requestQueueInterceptorId === 'undefined') {
     cache.requestQueueInterceptorId = instance.interceptors.request.use((request) => {
-      if(request.data.skipAuthRefresh)
+      if(request.data && request.data.skipAuthRefresh)
         return request
       return cache.refreshCall
           .catch(() => {


### PR DESCRIPTION
Caching request will allow refreshing axios with skipAuthRefresh go through

currently if the refreshLogic with delay work, it will be catch by the cacheRequest. By adding this line it allows request with skipAuthRefresh to pass through.

**Additional Detail:**
Fixing #120 