### PR TITLE
Add interceptNetworkError to AxiosAuthRefreshOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,22 @@ This prevents interceptor from running for each failed request.
 }
 ```
 
+#### Intercept on network error
+
+Some CORS APIs may not return CORS response headers when an HTTP 401 Unauthorized response is returned.
+In this scenario, the browser won't be able to read the response headers to determine the response status code.
+
+To intercept *any* network error, enable the `interceptNetworkError` option.
+
+CAUTION: This should be used as a last resort. If this is used to work around an API that doesn't support CORS
+with an HTTP 401 response, your retry logic can test for network connectivity attempting refresh authentication.
+
+```javascript
+{
+    interceptNetworkError: true // default: undefined
+}
+```
+
 ### Other usages of the library
 This library has also been used for:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export interface AxiosAuthRefreshOptions {
      */
     skipWhileRefreshing?: boolean;
     pauseInstanceWhileRefreshing?: boolean;
+    interceptNetworkError?: boolean;
     onRetry?: (requestConfig: AxiosRequestConfig) => AxiosRequestConfig
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,8 +48,18 @@ export function shouldInterceptError(
     return false;
   }
 
-  if (!error.response || !options.statusCodes.includes(parseInt(error.response.status))) {
+  if (
+    !(options.interceptNetworkError && !error.response && error.request.status === 0) &&
+    (!error.response || !options.statusCodes?.includes(parseInt(error.response.status)))
+  ) {
     return false;
+  }
+
+  // Copy config to response if there's a network error, so config can be modified and used in the retry
+  if (!error.response) {
+    error.response = {
+      config: error.config,
+    };
   }
 
   return !options.pauseInstanceWhileRefreshing || !cache.skipInstances.includes(instance);


### PR DESCRIPTION
Adds an option to allow intercepting a network error if `options.interceptNetworkError` is `true`.

This is useful for intercepting CORS failures. The Salesforce REST API is an example of an API that supports CORS when authenticated, but doesn't return CORS headers once an access token has expired or is invalid.

Implements #133 