### PR TITLE
Update axios peerDependency to ~0.21.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "test-coverage": "jest --coverage"
     },
     "peerDependencies": {
-        "axios": "~0.18.0 || ~0.19.1 || ~0.20.0"
+        "axios": "~0.18.0 || ~0.19.1 || ~0.20.0 || ~0.21.1"
     },
     "devDependencies": {
         "@types/jest": "^24.9.1",


### PR DESCRIPTION
I recently updated axios in one of my projects and got a warning as I was using a version that wasn't supported as a peer dependency. Not sure if you want to support all the versions that are listed in the `package.json` right now but I'm happy to change that to either way to whatever you think works best :).

```
warning " > axios-auth-refresh@3.0.0" has incorrect peer dependency "axios@~0.18.0 || ~0.19.1 || ~0.20.0".
```

Here's the latest axios version (`0.21.1` looks like it has a security fix in it as well): https://github.com/axios/axios/releases/tag/v0.21.1