### PR TITLE
skip request cache with skipAuthRefresh tag (w/ import)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -91,6 +91,8 @@ export function createRequestQueueInterceptor(
 ): number {
   if (typeof cache.requestQueueInterceptorId === 'undefined') {
     cache.requestQueueInterceptorId = instance.interceptors.request.use((request) => {
+      if(request.data.skipAuthRefresh)
+        return request
       return cache.refreshCall
           .catch(() => {
             throw new axios.Cancel('Request call failed');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -93,7 +93,7 @@ export function createRequestQueueInterceptor(
     cache: AxiosAuthRefreshCache,
     options: AxiosAuthRefreshOptions,
 ): number {
-  if (typeof cache.requestQueueInterceptorId === 'undefined') {
+  if (typeof cache.requestQueueInterceptorId === undefined) {
     cache.requestQueueInterceptorId = instance.interceptors.request.use((request: CustomAxiosRequestConfig) => {
       if(request?.skipAuthRefresh)
         return request

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance, AxiosPromise } from 'axios';
+import axios, { AxiosInstance, AxiosPromise, AxiosRequestConfig } from 'axios';
 import { AxiosAuthRefreshOptions, AxiosAuthRefreshCache } from './model';
 
 export interface CustomAxiosRequestConfig extends AxiosRequestConfig {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -91,7 +91,7 @@ export function createRequestQueueInterceptor(
 ): number {
   if (typeof cache.requestQueueInterceptorId === 'undefined') {
     cache.requestQueueInterceptorId = instance.interceptors.request.use((request) => {
-      if(request.data.skipAuthRefresh)
+      if(request.data && request.data.skipAuthRefresh)
         return request
       return cache.refreshCall
           .catch(() => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,10 @@
 import axios, { AxiosInstance, AxiosPromise } from 'axios';
 import { AxiosAuthRefreshOptions, AxiosAuthRefreshCache } from './model';
 
+export interface CustomAxiosRequestConfig extends AxiosRequestConfig {
+    skipAuthRefresh?: boolean
+}
+
 export const defaultOptions: AxiosAuthRefreshOptions = {
   statusCodes: [ 401 ],
   pauseInstanceWhileRefreshing: false,
@@ -90,8 +94,8 @@ export function createRequestQueueInterceptor(
     options: AxiosAuthRefreshOptions,
 ): number {
   if (typeof cache.requestQueueInterceptorId === 'undefined') {
-    cache.requestQueueInterceptorId = instance.interceptors.request.use((request) => {
-      if(request.data && request.data.skipAuthRefresh)
+    cache.requestQueueInterceptorId = instance.interceptors.request.use((request: CustomAxiosRequestConfig) => {
+      if(request?.skipAuthRefresh)
         return request
       return cache.refreshCall
           .catch(() => {


### PR DESCRIPTION
It's the same as https://github.com/Flyrell/axios-auth-refresh/pull/121 but with the addition of a missing `AxiosRequestConfig` import which prevented build to succeed).