### PR TITLE
Prettier

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run prettier:staged

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,3 @@
+printWidth: 120
+tabWidth: 4
+singleQuote: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,27 @@
 branches:
-  only:
-    - master
-    - /^v.*$/
+    only:
+        - master
+        - /^v.*$/
 
 language: node_js
 
 node_js:
-  - "stable"
+    - 'stable'
 
 cache:
-  directories:
-    - node_modules
+    directories:
+        - node_modules
 
 script:
-  - "npm test"
+    - 'npm test'
 
 before_deploy:
-  - "npm run build"
+    - 'npm run build'
 
 deploy:
-  edge: true
-  provider: npm
-  email: "$NPM_EMAIL"
-  api_key: "$NPM_API_TOKEN"
-  on:
-    tags: true
+    edge: true
+    provider: npm
+    email: '$NPM_EMAIL'
+    api_key: '$NPM_API_TOKEN'
+    on:
+        tags: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,10 +8,10 @@ from axios' [CONTRIBUTING](https://raw.githubusercontent.com/axios/axios/master/
 
 Commit messages should be verb based, using the following pattern:
 
-- `Fixing ...`
-- `Adding ...`
-- `Updating ...`
-- `Removing ...`
+-   `Fixing ...`
+-   `Adding ...`
+-   `Updating ...`
+-   `Removing ...`
 
 ### Documentation
 
@@ -24,4 +24,5 @@ Please, always include changes to `dist/` in your pull request.
 Please, do not include any `OS/IDE specific files` in your pull request.
 
 ### Build
+
 Please, use `npm run build` to build the package.

--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@
 ![Package types definitions](https://img.shields.io/npm/types/axios-auth-refresh)
 
 # axios-auth-refresh
+
 Library that helps you implement automatic refresh of authorization
 via axios [interceptors](https://github.com/axios/axios#interceptors).
 You can easily intercept the original request when it fails, refresh the authorization and continue with the original request,
 without any user interaction.
 
 What happens when the request fails due to authorization is all up to you.
-You can either run a refresh call for a new authorization token or run a custom logic. 
+You can either run a refresh call for a new authorization token or run a custom logic.
 
 The plugin stalls additional requests that have come in while waiting for a new authorization token
 and resolves them when a new token is available.
@@ -36,21 +37,24 @@ createAuthRefreshInterceptor(
 ```
 
 #### Parameters
-- `axios` - an instance of Axios
-- `refreshAuthLogic` - a Function used for refreshing authorization (**must return a promise**).
-Accepts exactly one parameter, which is the `failedRequest` returned by the original call.
-- `options` - object with settings for interceptor (See [available options](#available-options))
+
+-   `axios` - an instance of Axios
+-   `refreshAuthLogic` - a Function used for refreshing authorization (**must return a promise**).
+    Accepts exactly one parameter, which is the `failedRequest` returned by the original call.
+-   `options` - object with settings for interceptor (See [available options](#available-options))
 
 #### Returns
+
 Interceptor `id` in case you want to reject it manually.
 
 ## Usage
+
 In order to activate the interceptors, you need to import a function from `axios-auth-refresh`
-which is *exported by default* and call it with the **axios instance** you want the interceptors for, 
+which is _exported by default_ and call it with the **axios instance** you want the interceptors for,
 as well as the **refresh authorization function** where you need to write the logic for refreshing the authorization.
 
-The interceptors will then be bound onto the axios instance, and the specified logic will be run whenever a [401 (Unauthorized)](https://httpstatuses.com/401) status code 
-is returned from a server (or any other status code you provide in options). All the new requests created while the refreshAuthLogic has been processing will be bound onto the 
+The interceptors will then be bound onto the axios instance, and the specified logic will be run whenever a [401 (Unauthorized)](https://httpstatuses.com/401) status code
+is returned from a server (or any other status code you provide in options). All the new requests created while the refreshAuthLogic has been processing will be bound onto the
 Promise returned from the refreshAuthLogic function. This means that the requests will be resolved when a new access token has been fetched or when the refreshing logic failed.
 
 ```javascript
@@ -58,20 +62,19 @@ import axios from 'axios';
 import createAuthRefreshInterceptor from 'axios-auth-refresh';
 
 // Function that will be called to refresh authorization
-const refreshAuthLogic = failedRequest => axios.post('https://www.example.com/auth/token/refresh').then(tokenRefreshResponse => {
-    localStorage.setItem('token', tokenRefreshResponse.data.token);
-    failedRequest.response.config.headers['Authorization'] = 'Bearer ' + tokenRefreshResponse.data.token;
-    return Promise.resolve();
-});
+const refreshAuthLogic = (failedRequest) =>
+    axios.post('https://www.example.com/auth/token/refresh').then((tokenRefreshResponse) => {
+        localStorage.setItem('token', tokenRefreshResponse.data.token);
+        failedRequest.response.config.headers['Authorization'] = 'Bearer ' + tokenRefreshResponse.data.token;
+        return Promise.resolve();
+    });
 
 // Instantiate the interceptor
 createAuthRefreshInterceptor(axios, refreshAuthLogic);
 
-// Make a call. If it returns a 401 error, the refreshAuthLogic will be run, 
+// Make a call. If it returns a 401 error, the refreshAuthLogic will be run,
 // and the request retried with the new token
-axios.get('https://www.example.com/restricted/area')
-    .then(/* ... */)
-    .catch(/* ... */);
+axios.get('https://www.example.com/restricted/area').then(/* ... */).catch(/* ... */);
 ```
 
 #### Skipping the interceptor
@@ -82,29 +85,33 @@ axios.get('https://www.example.com/restricted/area')
 
 There's a possibility to skip the logic of the interceptor for specific calls.
 To do this, you need to pass the `skipAuthRefresh` option to the request config for each request you don't want to intercept.
+
 ```javascript
 axios.get('https://www.example.com/', { skipAuthRefresh: true });
 ```
 
 If you're using TypeScript you can import the custom request config interface from `axios-auth-refresh`.
+
 ```typescript
 import { AxiosAuthRefreshRequestConfig } from 'axios-auth-refresh';
 ```
 
 #### Request interceptor
+
 Since this plugin automatically stalls additional requests while refreshing the token,
-it is a good idea to **wrap your request logic in a function**, 
+it is a good idea to **wrap your request logic in a function**,
 to make sure the stalled requests are using the newly fetched data (like token).
 
 Example of sending the tokens:
+
 ```javascript
 // Obtain the fresh token each time the function is called
-function getAccessToken(){
+function getAccessToken() {
     return localStorage.getItem('token');
 }
 
 // Use interceptor to inject the token to requests
-axios.interceptors.request.use(request => {
+axios.interceptors.request.use((request) => {
     request.headers['Authorization'] = `Bearer ${getAccessToken()}`;
     return request;
 });
@@ -112,22 +119,23 @@ axios.interceptors.request.use(request => {
 
 ## Available options
 
-#### Status codes to intercept 
+#### Status codes to intercept
 
 You can specify multiple status codes that you want the interceptor to run for.
 
 ```javascript
 {
-    statusCodes: [ 401, 403 ] // default: [ 401 ]
+    statusCodes: [401, 403]; // default: [ 401 ]
 }
 ```
+
 #### Customize intercept logic
 
 You can specify multiple status codes that you want the interceptor to run for.
 
 ```javascript
 {
-    shouldRefresh: (error) => error?.response?.data?.business_error_code === 100385
+    shouldRefresh: (error) => error?.response?.data?.business_error_code === 100385;
 }
 ```
 
@@ -138,7 +146,7 @@ Default value is `undefined` and the instance passed to `createAuthRefreshInterc
 
 ```javascript
 {
-    retryInstance: someAxiosInstance // default: undefined
+    retryInstance: someAxiosInstance; // default: undefined
 }
 ```
 
@@ -149,7 +157,7 @@ stalled request is called with the request configuration object.
 
 ```javascript
 {
-    onRetry: (requestConfig) => ({ ...requestConfig, baseURL: '' }) // default: undefined
+    onRetry: (requestConfig) => ({ ...requestConfig, baseURL: '' }); // default: undefined
 }
 ```
 
@@ -168,7 +176,7 @@ This prevents interceptor from running for each failed request.
 
 ```javascript
 {
-    pauseInstanceWhileRefreshing: true // default: false
+    pauseInstanceWhileRefreshing: true; // default: false
 }
 ```
 
@@ -177,22 +185,23 @@ This prevents interceptor from running for each failed request.
 Some CORS APIs may not return CORS response headers when an HTTP 401 Unauthorized response is returned.
 In this scenario, the browser won't be able to read the response headers to determine the response status code.
 
-To intercept *any* network error, enable the `interceptNetworkError` option.
+To intercept _any_ network error, enable the `interceptNetworkError` option.
 
 CAUTION: This should be used as a last resort. If this is used to work around an API that doesn't support CORS
 with an HTTP 401 response, your retry logic can test for network connectivity attempting refresh authentication.
 
 ```javascript
 {
-    interceptNetworkError: true // default: undefined
+    interceptNetworkError: true; // default: undefined
 }
 ```
 
 ### Other usages of the library
+
 This library has also been used for:
 
-- Automatic request throttling by [@amcsi](https://github.com/amcsi)
-- OTP challenges with Google2FA by [@LeoniePhiline](https://github.com/LeoniePhiline)
+-   Automatic request throttling by [@amcsi](https://github.com/amcsi)
+-   OTP challenges with Google2FA by [@LeoniePhiline](https://github.com/LeoniePhiline)
 
 have you used it for something else? Create a PR with your use case to share it.
 
@@ -200,20 +209,23 @@ have you used it for something else? Create a PR with your use case to share it.
 
 ### Changelog
 
-- **v3.1.0**
-  - axios v0.21.1 support
-  - `interceptNetworkError` option introduced. See [#133](https://github.com/Flyrell/axios-auth-refresh/issues/133).
+-   **v3.1.0**
 
-- **v3.0.0**
-  - `skipWhileRefresh` flag has been deprecated due to its unclear name and its logic has been moved to `pauseInstanceWhileRefreshing` flag
-  - `pauseInstanceWhileRefreshing` is set to `false` by default
+    -   axios v0.21.1 support
+    -   `interceptNetworkError` option introduced. See [#133](https://github.com/Flyrell/axios-auth-refresh/issues/133).
+
+-   **v3.0.0**
+    -   `skipWhileRefresh` flag has been deprecated due to its unclear name and its logic has been moved to `pauseInstanceWhileRefreshing` flag
+    -   `pauseInstanceWhileRefreshing` is set to `false` by default
 
 ---
 
 #### Want to help?
+
 Check out [contribution guide](CONTRIBUTING.md) or my [patreon page!](https://www.patreon.com/dawidzbinski)
 
 ---
 
 #### Special thanks to [JetBrains](https://www.jetbrains.com/?from=axios-auth-refresh) for providing the IDE for our library
+
 <a href="https://www.jetbrains.com/?from=axios-auth-refresh" title="Link to JetBrains"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/1a/JetBrains_Logo_2016.svg/128px-JetBrains_Logo_2016.svg.png" alt="JetBrains"></a>

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ You can specify multiple status codes that you want the interceptor to run for.
 
 ```javascript
 {
-    statusCodes: [401, 403]; // default: [ 401 ]
+    statusCodes: [401, 403], // default: [ 401 ]
 }
 ```
 
@@ -135,7 +135,8 @@ You can specify multiple status codes that you want the interceptor to run for.
 
 ```javascript
 {
-    shouldRefresh: (error) => error?.response?.data?.business_error_code === 100385;
+    shouldRefresh: (error) =>
+        error?.response?.data?.business_error_code === 100385,
 }
 ```
 
@@ -146,7 +147,7 @@ Default value is `undefined` and the instance passed to `createAuthRefreshInterc
 
 ```javascript
 {
-    retryInstance: someAxiosInstance; // default: undefined
+    retryInstance: someAxiosInstance, // default: undefined
 }
 ```
 
@@ -157,7 +158,7 @@ stalled request is called with the request configuration object.
 
 ```javascript
 {
-    onRetry: (requestConfig) => ({ ...requestConfig, baseURL: '' }); // default: undefined
+    onRetry: (requestConfig) => ({ ...requestConfig, baseURL: '' }), // default: undefined
 }
 ```
 
@@ -176,7 +177,7 @@ This prevents interceptor from running for each failed request.
 
 ```javascript
 {
-    pauseInstanceWhileRefreshing: true; // default: false
+    pauseInstanceWhileRefreshing: true, // default: false
 }
 ```
 
@@ -192,7 +193,7 @@ with an HTTP 401 response, your retry logic can test for network connectivity at
 
 ```javascript
 {
-    interceptNetworkError: true; // default: undefined
+    interceptNetworkError: true, // default: undefined
 }
 ```
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
+    preset: 'ts-jest',
+    testEnvironment: 'node',
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,10 @@
                 "babel-loader": "^8.2.2",
                 "clean-webpack-plugin": "^4.0.0",
                 "declaration-bundler-webpack-plugin": "^1.0.3",
+                "husky": "^8.0.1",
                 "jest": "^27.2.0",
+                "prettier": "2.6.2",
+                "pretty-quick": "^3.1.3",
                 "terser-webpack-plugin": "^5.2.4",
                 "ts-jest": "^27.0.5",
                 "ts-loader": "^9.2.5",
@@ -1722,6 +1725,15 @@
                 "sprintf-js": "~1.0.2"
             }
         },
+        "node_modules/array-differ": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
+            "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/array-union": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -1741,6 +1753,15 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/arrify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+            "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/asynckit": {
@@ -2433,6 +2454,15 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/end-of-stream": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+            "dev": true,
+            "dependencies": {
+                "once": "^1.4.0"
+            }
+        },
         "node_modules/enhanced-resolve": {
             "version": "5.9.3",
             "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.3.tgz",
@@ -2949,6 +2979,21 @@
                 "node": ">=10.17.0"
             }
         },
+        "node_modules/husky": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
+            "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
+            "dev": true,
+            "bin": {
+                "husky": "lib/bin.js"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/typicode"
+            }
+        },
         "node_modules/iconv-lite": {
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -2959,6 +3004,15 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ignore": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 4"
             }
         },
         "node_modules/import-local": {
@@ -5220,11 +5274,45 @@
                 "node": "*"
             }
         },
+        "node_modules/mri": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+            "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
+        },
+        "node_modules/multimatch": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
+            "integrity": "sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/minimatch": "^3.0.3",
+                "array-differ": "^3.0.0",
+                "array-union": "^2.1.0",
+                "arrify": "^2.0.1",
+                "minimatch": "^3.0.4"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/multimatch/node_modules/array-union": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
@@ -5513,6 +5601,21 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/prettier": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+            "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+            "dev": true,
+            "bin": {
+                "prettier": "bin-prettier.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
         "node_modules/pretty-format": {
             "version": "27.5.1",
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -5539,6 +5642,143 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/pretty-quick": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-3.1.3.tgz",
+            "integrity": "sha512-kOCi2FJabvuh1as9enxYmrnBC6tVMoVOenMaBqRfsvBHB0cbpYHjdQEpSglpASDFEXVwplpcGR4CLEaisYAFcA==",
+            "dev": true,
+            "dependencies": {
+                "chalk": "^3.0.0",
+                "execa": "^4.0.0",
+                "find-up": "^4.1.0",
+                "ignore": "^5.1.4",
+                "mri": "^1.1.5",
+                "multimatch": "^4.0.0"
+            },
+            "bin": {
+                "pretty-quick": "bin/pretty-quick.js"
+            },
+            "engines": {
+                "node": ">=10.13"
+            },
+            "peerDependencies": {
+                "prettier": ">=2.0.0"
+            }
+        },
+        "node_modules/pretty-quick/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/pretty-quick/node_modules/chalk": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+            "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/pretty-quick/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/pretty-quick/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "node_modules/pretty-quick/node_modules/execa": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+            "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+            "dev": true,
+            "dependencies": {
+                "cross-spawn": "^7.0.0",
+                "get-stream": "^5.0.0",
+                "human-signals": "^1.1.1",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.0",
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/pretty-quick/node_modules/get-stream": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+            "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+            "dev": true,
+            "dependencies": {
+                "pump": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/pretty-quick/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/pretty-quick/node_modules/human-signals": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+            "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+            "dev": true,
+            "engines": {
+                "node": ">=8.12.0"
+            }
+        },
+        "node_modules/pretty-quick/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/prompts": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -5557,6 +5797,16 @@
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
             "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
             "dev": true
+        },
+        "node_modules/pump": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+            "dev": true,
+            "dependencies": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
         },
         "node_modules/punycode": {
             "version": "2.1.1",
@@ -8166,6 +8416,12 @@
                 "sprintf-js": "~1.0.2"
             }
         },
+        "array-differ": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
+            "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
+            "dev": true
+        },
         "array-union": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -8179,6 +8435,12 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
             "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+            "dev": true
+        },
+        "arrify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+            "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
             "dev": true
         },
         "asynckit": {
@@ -8715,6 +8977,15 @@
             "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
             "dev": true
         },
+        "end-of-stream": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+            "dev": true,
+            "requires": {
+                "once": "^1.4.0"
+            }
+        },
         "enhanced-resolve": {
             "version": "5.9.3",
             "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.3.tgz",
@@ -9090,6 +9361,12 @@
             "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
             "dev": true
         },
+        "husky": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
+            "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
+            "dev": true
+        },
         "iconv-lite": {
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -9098,6 +9375,12 @@
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
             }
+        },
+        "ignore": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+            "dev": true
         },
         "import-local": {
             "version": "3.1.0",
@@ -10790,11 +11073,38 @@
                 "brace-expansion": "^1.1.7"
             }
         },
+        "mri": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+            "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+            "dev": true
+        },
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
+        },
+        "multimatch": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
+            "integrity": "sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==",
+            "dev": true,
+            "requires": {
+                "@types/minimatch": "^3.0.3",
+                "array-differ": "^3.0.0",
+                "array-union": "^2.1.0",
+                "arrify": "^2.0.1",
+                "minimatch": "^3.0.4"
+            },
+            "dependencies": {
+                "array-union": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+                    "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+                    "dev": true
+                }
+            }
         },
         "natural-compare": {
             "version": "1.4.0",
@@ -11011,6 +11321,12 @@
             "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
             "dev": true
         },
+        "prettier": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+            "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+            "dev": true
+        },
         "pretty-format": {
             "version": "27.5.1",
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -11030,6 +11346,103 @@
                 }
             }
         },
+        "pretty-quick": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-3.1.3.tgz",
+            "integrity": "sha512-kOCi2FJabvuh1as9enxYmrnBC6tVMoVOenMaBqRfsvBHB0cbpYHjdQEpSglpASDFEXVwplpcGR4CLEaisYAFcA==",
+            "dev": true,
+            "requires": {
+                "chalk": "^3.0.0",
+                "execa": "^4.0.0",
+                "find-up": "^4.1.0",
+                "ignore": "^5.1.4",
+                "mri": "^1.1.5",
+                "multimatch": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "execa": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+                    "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^7.0.0",
+                        "get-stream": "^5.0.0",
+                        "human-signals": "^1.1.1",
+                        "is-stream": "^2.0.0",
+                        "merge-stream": "^2.0.0",
+                        "npm-run-path": "^4.0.0",
+                        "onetime": "^5.1.0",
+                        "signal-exit": "^3.0.2",
+                        "strip-final-newline": "^2.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+                    "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "human-signals": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+                    "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
         "prompts": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -11045,6 +11458,16 @@
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
             "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
             "dev": true
+        },
+        "pump": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
         },
         "punycode": {
             "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
         "test": "jest",
         "test-coverage": "jest --coverage",
         "prettier": "prettier --write .",
-        "prettier:staged": "pretty-quick --staged",
-        "prepare": "husky install"
+        "prettier:staged": "pretty-quick --staged"
     },
     "peerDependencies": {
         "axios": ">= 0.18 < 0.19.0 || >= 0.19.1"
@@ -37,7 +36,7 @@
         "declaration-bundler-webpack-plugin": "^1.0.3",
         "husky": "^8.0.1",
         "jest": "^27.2.0",
-        "prettier": "2.6.2",
+        "prettier": "^2.6.2",
         "pretty-quick": "^3.1.3",
         "terser-webpack-plugin": "^5.2.4",
         "ts-jest": "^27.0.5",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
         "dev": "webpack --mode development",
         "build": "webpack --mode production",
         "test": "jest",
-        "test-coverage": "jest --coverage"
+        "test-coverage": "jest --coverage",
+        "prettier": "prettier --write .",
+        "prettier:staged": "pretty-quick --staged",
+        "prepare": "husky install"
     },
     "peerDependencies": {
         "axios": ">= 0.18 < 0.19.0 || >= 0.19.1"
@@ -32,7 +35,10 @@
         "babel-loader": "^8.2.2",
         "clean-webpack-plugin": "^4.0.0",
         "declaration-bundler-webpack-plugin": "^1.0.3",
+        "husky": "^8.0.1",
         "jest": "^27.2.0",
+        "prettier": "2.6.2",
+        "pretty-quick": "^3.1.3",
         "terser-webpack-plugin": "^5.2.4",
         "ts-jest": "^27.0.5",
         "ts-loader": "^9.2.5",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
         "test": "jest",
         "test-coverage": "jest --coverage",
         "prettier": "prettier --write .",
-        "prettier:staged": "pretty-quick --staged"
+        "prettier:staged": "pretty-quick --staged",
+        "prepare": "husky install"
     },
     "peerDependencies": {
         "axios": ">= 0.18 < 0.19.0 || >= 0.19.1"

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { AxiosAuthRefreshCache, AxiosAuthRefreshRequestConfig } from '../model';
 import axios, { AxiosRequestConfig, AxiosStatic } from 'axios';
-import createAuthRefreshInterceptor, { AxiosAuthRefreshOptions } from "../index";
+import createAuthRefreshInterceptor, { AxiosAuthRefreshOptions } from '../index';
 import {
     unsetCache,
     mergeOptions,
@@ -9,13 +9,13 @@ import {
     createRefreshCall,
     shouldInterceptError,
     createRequestQueueInterceptor,
-} from "../utils";
+} from '../utils';
 
 const mockedAxios: () => AxiosStatic | any = () => {
     const bag = {
         request: [],
         response: [],
-        has: jest.fn((type: 'request'|'response', id: number) => bag[type].includes(id))
+        has: jest.fn((type: 'request' | 'response', id: number) => bag[type].includes(id)),
     };
     return {
         interceptors: {
@@ -26,8 +26,8 @@ const mockedAxios: () => AxiosStatic | any = () => {
                     return i;
                 }),
                 eject: jest.fn((i) => {
-                    bag.request = bag.request.filter(n => n !== i);
-                })
+                    bag.request = bag.request.filter((n) => n !== i);
+                }),
             },
             response: {
                 use: jest.fn(() => {
@@ -36,14 +36,14 @@ const mockedAxios: () => AxiosStatic | any = () => {
                     return i;
                 }),
                 eject: jest.fn((i) => {
-                    bag.response = bag.response.filter(n => n !== i);
-                })
+                    bag.response = bag.response.filter((n) => n !== i);
+                }),
             },
-            has: bag.has
+            has: bag.has,
         },
         defaults: {
-            params: {}
-        }
+            params: {},
+        },
     };
 };
 
@@ -57,38 +57,36 @@ const sleep = (ms) => {
 };
 
 describe('Merges configs', () => {
-
     it('source and target are the same', () => {
-        const source: AxiosAuthRefreshOptions = { statusCodes: [ 204 ] };
-        const target: AxiosAuthRefreshOptions = { statusCodes: [ 204 ] };
-        expect(mergeOptions(target, source)).toEqual({ statusCodes: [ 204 ] });
+        const source: AxiosAuthRefreshOptions = { statusCodes: [204] };
+        const target: AxiosAuthRefreshOptions = { statusCodes: [204] };
+        expect(mergeOptions(target, source)).toEqual({ statusCodes: [204] });
     });
 
     it('source is different than the target', () => {
-        const source: AxiosAuthRefreshOptions = { statusCodes: [ 302 ] };
-        const target: AxiosAuthRefreshOptions = { statusCodes: [ 204 ] };
-        expect(mergeOptions(target, source)).toEqual({ statusCodes: [ 302 ] });
+        const source: AxiosAuthRefreshOptions = { statusCodes: [302] };
+        const target: AxiosAuthRefreshOptions = { statusCodes: [204] };
+        expect(mergeOptions(target, source)).toEqual({ statusCodes: [302] });
     });
 
     it('source is empty', () => {
         const source: AxiosAuthRefreshOptions = {};
-        const target: AxiosAuthRefreshOptions = { statusCodes: [ 204 ] };
-        expect(mergeOptions(target, source)).toEqual({ statusCodes: [ 204 ] });
+        const target: AxiosAuthRefreshOptions = { statusCodes: [204] };
+        expect(mergeOptions(target, source)).toEqual({ statusCodes: [204] });
     });
 });
 
 describe('Determines if the response should be intercepted', () => {
-
     let cache: AxiosAuthRefreshCache = undefined;
     beforeEach(() => {
         cache = {
             skipInstances: [],
             refreshCall: undefined,
-            requestQueueInterceptorId: undefined
+            requestQueueInterceptorId: undefined,
         };
     });
 
-    const options = { statusCodes: [ 401 ] };
+    const options = { statusCodes: [401] };
 
     it('no error object provided', () => {
         expect(shouldInterceptError(undefined, options, axios, cache)).toBeFalsy();
@@ -117,7 +115,7 @@ describe('Determines if the response should be intercepted', () => {
     it('when skipAuthRefresh flag is set ot true', () => {
         const error = {
             response: { status: 401 },
-            config: { skipAuthRefresh: true }
+            config: { skipAuthRefresh: true },
         };
         expect(shouldInterceptError(error, options, axios, cache)).toBeFalsy();
     });
@@ -125,7 +123,7 @@ describe('Determines if the response should be intercepted', () => {
     it('when skipAuthRefresh flag is set to false', () => {
         const error = {
             response: { status: 401 },
-            config: { skipAuthRefresh: false }
+            config: { skipAuthRefresh: false },
         };
         expect(shouldInterceptError(error, options, axios, cache)).toBeTruthy();
     });
@@ -141,7 +139,7 @@ describe('Determines if the response should be intercepted', () => {
         const error = {
             response: { status: 401 },
         };
-        const newCache = { ...cache, skipInstances: [ axios ] };
+        const newCache = { ...cache, skipInstances: [axios] };
         const newOptions = { ...options, pauseInstanceWhileRefreshing: true };
         expect(shouldInterceptError(error, newOptions, axios, newCache)).toBeFalsy();
     });
@@ -158,7 +156,7 @@ describe('Determines if the response should be intercepted', () => {
         const error = {
             response: { status: 401 },
         };
-        const newOptions:AxiosAuthRefreshOptions = { ...options, shouldRefresh: () => true};
+        const newOptions: AxiosAuthRefreshOptions = { ...options, shouldRefresh: () => true };
         expect(shouldInterceptError(error, newOptions, axios, cache)).toBeTruthy();
     });
 
@@ -166,24 +164,22 @@ describe('Determines if the response should be intercepted', () => {
         const error = {
             response: { status: 401 },
         };
-        const newOptions:AxiosAuthRefreshOptions = { ...options, shouldRefresh: () => false};
+        const newOptions: AxiosAuthRefreshOptions = { ...options, shouldRefresh: () => false };
         expect(shouldInterceptError(error, newOptions, axios, cache)).toBeFalsy();
     });
 });
 
 describe('Creates refresh call', () => {
-
     let cache: AxiosAuthRefreshCache = undefined;
     beforeEach(() => {
         cache = {
             skipInstances: [],
             refreshCall: undefined,
-            requestQueueInterceptorId: undefined
+            requestQueueInterceptorId: undefined,
         };
     });
 
     it('warns if refreshTokenCall does not return a promise', async () => {
-
         // Just so we don't trigger the console.warn (looks better in terminal)
         const tmp = console.warn;
         const mocked = jest.fn();
@@ -224,13 +220,12 @@ describe('Creates refresh call', () => {
 });
 
 describe('Requests interceptor', () => {
-
     let cache: AxiosAuthRefreshCache = undefined;
     beforeEach(() => {
         cache = {
             skipInstances: [],
             refreshCall: undefined,
-            requestQueueInterceptorId: undefined
+            requestQueueInterceptorId: undefined,
         };
     });
 
@@ -254,10 +249,14 @@ describe('Requests interceptor', () => {
             let refreshed = 0;
             const instance = axios.create();
             createRequestQueueInterceptor(instance, cache, {});
-            createRefreshCall({}, async () => {
-                await sleep(400);
-                ++refreshed;
-            }, cache);
+            createRefreshCall(
+                {},
+                async () => {
+                    await sleep(400);
+                    ++refreshed;
+                },
+                cache
+            );
             await instance.get('http://example.com').then(() => expect(refreshed).toBe(1));
             await instance.get('http://example.com').then(() => expect(refreshed).toBe(1));
         } catch (e) {
@@ -265,19 +264,23 @@ describe('Requests interceptor', () => {
         }
     });
 
-    it('doesn\'t intercept skipped request', async () => {
+    it("doesn't intercept skipped request", async () => {
         try {
             let refreshed = 0;
             const instance = axios.create();
             createRequestQueueInterceptor(instance, cache, {});
-            createRefreshCall({}, async () => {
-                await sleep(400);
-                ++refreshed;
-            }, cache);
-            await instance.get('http://example.com')
-              .then(() => expect(refreshed).toBe(1));
-            await instance.get('http://example.com', <AxiosAuthRefreshRequestConfig>{ skipAuthRefresh: true })
-              .then(() => expect(refreshed).toBe(1));
+            createRefreshCall(
+                {},
+                async () => {
+                    await sleep(400);
+                    ++refreshed;
+                },
+                cache
+            );
+            await instance.get('http://example.com').then(() => expect(refreshed).toBe(1));
+            await instance
+                .get('http://example.com', <AxiosAuthRefreshRequestConfig>{ skipAuthRefresh: true })
+                .then(() => expect(refreshed).toBe(1));
         } catch (e) {
             expect(e).toBeFalsy();
         }
@@ -285,15 +288,26 @@ describe('Requests interceptor', () => {
 
     it('cancels all requests when refreshing call failed', async () => {
         try {
-            let passed = 0, caught = 0;
+            let passed = 0,
+                caught = 0;
             const instance = axios.create();
             createRequestQueueInterceptor(instance, cache, {});
-            createRefreshCall({}, async () => {
-                await sleep(500);
-                return Promise.reject();
-            }, cache);
-            await instance.get('http://example.com').then(() => ++passed).catch(() => ++caught);
-            await instance.get('http://example.com').then(() => ++passed).catch(() => ++caught);
+            createRefreshCall(
+                {},
+                async () => {
+                    await sleep(500);
+                    return Promise.reject();
+                },
+                cache
+            );
+            await instance
+                .get('http://example.com')
+                .then(() => ++passed)
+                .catch(() => ++caught);
+            await instance
+                .get('http://example.com')
+                .then(() => ++passed)
+                .catch(() => ++caught);
             expect(passed).toBe(0);
             expect(caught).toBe(2);
         } catch (e) {
@@ -317,17 +331,20 @@ describe('Requests interceptor', () => {
         const instance = axios.create();
         const onRetry = jest.fn((requestConfig: AxiosRequestConfig) => requestConfig);
         createRequestQueueInterceptor(instance, cache, { onRetry });
-        createRefreshCall({}, async () => {
-            await sleep(500);
-            return Promise.resolve();
-        }, cache);
+        createRefreshCall(
+            {},
+            async () => {
+                await sleep(500);
+                return Promise.resolve();
+            },
+            cache
+        );
         await instance.get('http://example.com');
         expect(onRetry).toHaveBeenCalled();
     });
 });
 
 describe('Creates the overall interceptor correctly', () => {
-
     it('throws error when no function provided', () => {
         expect(() => createAuthRefreshInterceptor(axios, null)).toThrow();
     });
@@ -341,11 +358,11 @@ describe('Creates the overall interceptor correctly', () => {
     it('does not change the interceptors queue', async () => {
         try {
             const instance = axios.create();
-            const id = createAuthRefreshInterceptor(
-                axios,
-                () => instance.get('https://httpstat.us/200')
+            const id = createAuthRefreshInterceptor(axios, () => instance.get('https://httpstat.us/200'));
+            const id2 = instance.interceptors.response.use(
+                (req) => req,
+                (error) => Promise.reject(error)
             );
-            const id2 = instance.interceptors.response.use(req => req, error => Promise.reject(error));
             const interceptor1 = instance.interceptors.response['handlers'][id];
             const interceptor2 = instance.interceptors.response['handlers'][id2];
             try {
@@ -364,11 +381,10 @@ describe('Creates the overall interceptor correctly', () => {
 });
 
 describe('State is cleared', () => {
-
     const cache: AxiosAuthRefreshCache = {
         skipInstances: [],
         refreshCall: undefined,
-        requestQueueInterceptorId: undefined
+        requestQueueInterceptorId: undefined,
     };
 
     it('after refreshing call succeeds/fails', () => {

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,32 +1,32 @@
 import { AxiosError, AxiosInstance, AxiosRequestConfig } from 'axios';
 
 export interface AxiosAuthRefreshOptions {
-  statusCodes?: Array<number>;
-  /**
-   * Determine whether to refresh, if "shouldRefresh" is configured, The "statusCodes" logic will be ignored
-   * @param error AxiosError
-   * @returns boolean
-   */
-  shouldRefresh?(error: AxiosError): boolean;
-  retryInstance?: AxiosInstance;
-  interceptNetworkError?: boolean;
-  pauseInstanceWhileRefreshing?: boolean;
-  onRetry?: (requestConfig: AxiosRequestConfig) => AxiosRequestConfig | Promise<AxiosRequestConfig>;
+    statusCodes?: Array<number>;
+    /**
+     * Determine whether to refresh, if "shouldRefresh" is configured, The "statusCodes" logic will be ignored
+     * @param error AxiosError
+     * @returns boolean
+     */
+    shouldRefresh?(error: AxiosError): boolean;
+    retryInstance?: AxiosInstance;
+    interceptNetworkError?: boolean;
+    pauseInstanceWhileRefreshing?: boolean;
+    onRetry?: (requestConfig: AxiosRequestConfig) => AxiosRequestConfig | Promise<AxiosRequestConfig>;
 
-  /**
-   * @deprecated
-   * This flag has been deprecated in favor of `pauseInstanceWhileRefreshing` flag.
-   * Use `pauseInstanceWhileRefreshing` instead.
-   */
-  skipWhileRefreshing?: boolean;
+    /**
+     * @deprecated
+     * This flag has been deprecated in favor of `pauseInstanceWhileRefreshing` flag.
+     * Use `pauseInstanceWhileRefreshing` instead.
+     */
+    skipWhileRefreshing?: boolean;
 }
 
 export interface AxiosAuthRefreshCache {
-  skipInstances: AxiosInstance[];
-  refreshCall: Promise<any>|undefined;
-  requestQueueInterceptorId: number|undefined;
+    skipInstances: AxiosInstance[];
+    refreshCall: Promise<any> | undefined;
+    requestQueueInterceptorId: number | undefined;
 }
 
 export interface AxiosAuthRefreshRequestConfig extends AxiosRequestConfig {
-  skipAuthRefresh?: boolean;
+    skipAuthRefresh?: boolean;
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,32 +1,32 @@
 import { AxiosError, AxiosInstance, AxiosRequestConfig } from 'axios';
 
 export interface AxiosAuthRefreshOptions {
-  statusCodes?: Array<number>;
-  /**
-   * Determine whether to refresh, if "shouldRefresh" is configured, The "statusCodes" logic will be ignored
-   * @param error AxiosError
-   * @returns boolean
-   */
-  shouldRefresh?(error: AxiosError): boolean;
-  retryInstance?: AxiosInstance;
-  interceptNetworkError?: boolean;
-  pauseInstanceWhileRefreshing?: boolean;
-  onRetry?: (requestConfig: AxiosRequestConfig) => AxiosRequestConfig;
+    statusCodes?: Array<number>;
+    /**
+     * Determine whether to refresh, if "shouldRefresh" is configured, The "statusCodes" logic will be ignored
+     * @param error AxiosError
+     * @returns boolean
+     */
+    shouldRefresh?(error: AxiosError): boolean;
+    retryInstance?: AxiosInstance;
+    interceptNetworkError?: boolean;
+    pauseInstanceWhileRefreshing?: boolean;
+    onRetry?: (requestConfig: AxiosRequestConfig) => AxiosRequestConfig;
 
-  /**
-   * @deprecated
-   * This flag has been deprecated in favor of `pauseInstanceWhileRefreshing` flag.
-   * Use `pauseInstanceWhileRefreshing` instead.
-   */
-  skipWhileRefreshing?: boolean;
+    /**
+     * @deprecated
+     * This flag has been deprecated in favor of `pauseInstanceWhileRefreshing` flag.
+     * Use `pauseInstanceWhileRefreshing` instead.
+     */
+    skipWhileRefreshing?: boolean;
 }
 
 export interface AxiosAuthRefreshCache {
-  skipInstances: AxiosInstance[];
-  refreshCall: Promise<any>|undefined;
-  requestQueueInterceptorId: number|undefined;
+    skipInstances: AxiosInstance[];
+    refreshCall: Promise<any> | undefined;
+    requestQueueInterceptorId: number | undefined;
 }
 
 export interface AxiosAuthRefreshRequestConfig extends AxiosRequestConfig {
-  skipAuthRefresh?: boolean;
+    skipAuthRefresh?: boolean;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,10 +6,6 @@
         "declaration": true,
         "module": "commonjs"
     },
-    "include": [
-        "./src/index.ts"
-    ],
-    "exclude": [
-        "./src/**/__tests__"
-    ]
+    "include": ["./src/index.ts"],
+    "exclude": ["./src/**/__tests__"]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,31 +3,27 @@ const TerserPlugin = require('terser-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 
 module.exports = {
-    devtool: "hidden-source-map",
-    entry: "./src/index.ts",
-    externals: [ 'axios' ],
+    devtool: 'hidden-source-map',
+    entry: './src/index.ts',
+    externals: ['axios'],
     output: {
         path: path.resolve(__dirname, 'dist'),
         filename: 'index.min.js',
         library: {
             name: 'axios-auth-refresh',
-            type: 'umd'
+            type: 'umd',
         },
-        globalObject: 'this'
+        globalObject: 'this',
     },
     resolve: {
-        extensions: [".ts"]
+        extensions: ['.ts'],
     },
     module: {
-        rules: [
-            { test: /\.tsx?$/, loader: "ts-loader" }
-        ]
+        rules: [{ test: /\.tsx?$/, loader: 'ts-loader' }],
     },
     optimization: {
         minimize: true,
         minimizer: [new TerserPlugin()],
     },
-    plugins: [
-        new CleanWebpackPlugin()
-    ]
+    plugins: [new CleanWebpackPlugin()],
 };


### PR DESCRIPTION
This PR is best reviewed by commits. The first commit is the initial setup. In the second, only Prettier was run over all files.

# Prettier

Initial setup details:

-   Best practice: Fixed version of Prettier, because even a different patch version formats the code differently ([Prettier install](https://prettier.io/docs/en/install.html)).
-   Prettier command was created to run over all files that Prettier supports. In addition to TypeScript files, Markdown, among others, is also available.
-   Package `pretty-quick` added, which runs over the staged files before the commit.

Apart from that, Prettier was also run over all files.
