### PR TITLE
Fix the onRetry function

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -344,6 +344,47 @@ describe('Requests interceptor', () => {
     });
 });
 
+describe('Response interceptor', () => {
+    it('uses the request interceptor to call the onRetry callback before retrying the request', async () => {
+        const instance = axios.create();
+        const onRetry = jest.fn((requestConfig: AxiosRequestConfig) => {
+            // modify the url to one that will respond with status code 200
+            return {
+                ...requestConfig,
+                url: 'https://httpstat.us/200',
+            };
+        });
+        createAuthRefreshInterceptor(instance, (error) => Promise.resolve(), { onRetry });
+
+        await instance.get('https://httpstat.us/401');
+
+        expect(onRetry).toHaveBeenCalled();
+    });
+
+    it('uses the request interceptor to call the onRetry callback before retrying all the requests', async () => {
+        const instance = axios.create();
+        const onRetry = jest.fn((requestConfig: AxiosRequestConfig) => {
+            // modify the url to one that will respond with status code 200
+            return {
+                ...requestConfig,
+                url: 'https://httpstat.us/200',
+            };
+        });
+        createAuthRefreshInterceptor(instance, (error) => Promise.resolve(), { onRetry });
+
+        const requests = [
+            instance.get('https://httpstat.us/401'),
+            instance.get('https://httpstat.us/401'),
+            instance.get('https://httpstat.us/401'),
+            instance.get('https://httpstat.us/401'),
+        ];
+
+        await Promise.all(requests);
+
+        expect(onRetry).toHaveBeenCalledTimes(requests.length);
+    });
+});
+
 describe('Creates the overall interceptor correctly', () => {
     it('throws error when no function provided', () => {
         expect(() => createAuthRefreshInterceptor(axios, null)).toThrow();

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,9 +63,9 @@ export default function createAuthRefreshInterceptor(
             createRequestQueueInterceptor(instance, cache, options);
 
             return refreshing
-                .finally(() => unsetCache(instance, cache))
                 .catch((error) => Promise.reject(error))
-                .then(() => resendFailedRequest(error, getRetryInstance(instance, options)));
+                .then(() => resendFailedRequest(error, getRetryInstance(instance, options)))
+                .finally(() => unsetCache(instance, cache));
         }
     );
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -98,7 +98,6 @@ export function createRequestQueueInterceptor(
 ): number {
     if (typeof cache.requestQueueInterceptorId === 'undefined') {
         cache.requestQueueInterceptorId = instance.interceptors.request.use((request: CustomAxiosRequestConfig) => {
-            if (request?.skipAuthRefresh) return request;
             return cache.refreshCall
                 .catch(() => {
                     throw new axios.Cancel('Request call failed');


### PR DESCRIPTION
Fixes #190

The `onRetry` function was never being called for any stalled requests because:

- the request interceptor is being ejected by the `finally` function before it can intercept the request that is being re-sent
- the `resendFailedRequest` function is always setting the `skipAuthRefresh` configuration property to `true` which always causes the request interceptor to skip calling the `onRetry` function

The existing test for the `onRetry` function was testing that the function is called from the request interceptor. Two new tests have been added to test that the `onRetry` function is called from the response interceptor.

See https://github.com/Flyrell/axios-auth-refresh/issues/190#issuecomment-1293309040 for more info on this issue.