### PR TITLE
Fixed compile-problems against latest axios 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
             "license": "MIT",
             "devDependencies": {
                 "@types/jest": "^28.1.6",
-                "axios": "^1.2.2",
+                "@types/node": "~20.8.10",
+                "axios": "^1.6.0",
                 "babel-loader": "^9.1.0",
                 "clean-webpack-plugin": "^4.0.0",
                 "declaration-bundler-webpack-plugin": "^1.0.3",
@@ -1427,10 +1428,13 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "18.8.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.2.tgz",
-            "integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA==",
-            "dev": true
+            "version": "20.8.10",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
+            "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
         },
         "node_modules/@types/prettier": {
             "version": "2.7.1",
@@ -1850,9 +1854,9 @@
             "dev": true
         },
         "node_modules/axios": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.2.tgz",
-            "integrity": "sha512-bz/J4gS2S3I7mpN/YZfGFTqhXTYzRho8Ay38w2otuuDR322KzFIWm/4W2K6gIwvWaws5n+mnb7D1lN9uD+QH6Q==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
+            "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
             "dev": true,
             "dependencies": {
                 "follow-redirects": "^1.15.0",
@@ -6265,6 +6269,12 @@
                 "node": ">=4.2.0"
             }
         },
+        "node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "dev": true
+        },
         "node_modules/update-browserslist-db": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.9.tgz",
@@ -7718,10 +7728,13 @@
             "dev": true
         },
         "@types/node": {
-            "version": "18.8.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.2.tgz",
-            "integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA==",
-            "dev": true
+            "version": "20.8.10",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
+            "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
+            "dev": true,
+            "requires": {
+                "undici-types": "~5.26.4"
+            }
         },
         "@types/prettier": {
             "version": "2.7.1",
@@ -8067,9 +8080,9 @@
             "dev": true
         },
         "axios": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.2.tgz",
-            "integrity": "sha512-bz/J4gS2S3I7mpN/YZfGFTqhXTYzRho8Ay38w2otuuDR322KzFIWm/4W2K6gIwvWaws5n+mnb7D1lN9uD+QH6Q==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
+            "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
             "dev": true,
             "requires": {
                 "follow-redirects": "^1.15.0",
@@ -11297,6 +11310,12 @@
             "version": "4.9.4",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
             "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+            "dev": true
+        },
+        "undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
             "dev": true
         },
         "update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "axios-auth-refresh",
-    "version": "3.3.6",
+    "version": "4.0.0",
     "description": "Axios plugin which makes it very easy to automatically refresh the authorization tokens of your clients",
     "keywords": [
         "axios",
@@ -28,11 +28,11 @@
         "prepare": "husky install"
     },
     "peerDependencies": {
-        "axios": ">= 0.18 < 0.19.0 || >= 0.19.1"
+        "axios": ">= 1.6.0"
     },
     "devDependencies": {
         "@types/jest": "^28.1.6",
-        "axios": "^1.2.2",
+        "axios": "^1.6.0",
         "babel-loader": "^9.1.0",
         "clean-webpack-plugin": "^4.0.0",
         "declaration-bundler-webpack-plugin": "^1.0.3",
@@ -45,7 +45,8 @@
         "ts-loader": "^9.3.1",
         "typescript": "^4.9.4",
         "webpack": "^5.73.0",
-        "webpack-cli": "^5.0.1"
+        "webpack-cli": "^5.0.1",
+        "@types/node": "~20.8.10"
     },
     "files": [
         "dist",

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 import { AxiosAuthRefreshCache, AxiosAuthRefreshRequestConfig } from '../model';
-import axios, { AxiosRequestConfig, AxiosStatic } from 'axios';
+import axios, { InternalAxiosRequestConfig, AxiosStatic } from 'axios';
 import createAuthRefreshInterceptor, { AxiosAuthRefreshOptions } from '../index';
 import {
     unsetCache,
@@ -329,7 +329,7 @@ describe('Requests interceptor', () => {
 
     it('calls the onRetry callback before retrying the request', async () => {
         const instance = axios.create();
-        const onRetry = jest.fn((requestConfig: AxiosRequestConfig) => requestConfig);
+        const onRetry = jest.fn((requestConfig: InternalAxiosRequestConfig) => requestConfig);
         createRequestQueueInterceptor(instance, cache, { onRetry });
         createRefreshCall(
             {},
@@ -347,7 +347,7 @@ describe('Requests interceptor', () => {
 describe('Response interceptor', () => {
     it('uses the request interceptor to call the onRetry callback before retrying the request', async () => {
         const instance = axios.create();
-        const onRetry = jest.fn((requestConfig: AxiosRequestConfig) => {
+        const onRetry = jest.fn((requestConfig: InternalAxiosRequestConfig) => {
             // modify the url to one that will respond with status code 200
             return {
                 ...requestConfig,
@@ -363,7 +363,7 @@ describe('Response interceptor', () => {
 
     it('uses the request interceptor to call the onRetry callback before retrying all the requests', async () => {
         const instance = axios.create();
-        const onRetry = jest.fn((requestConfig: AxiosRequestConfig) => {
+        const onRetry = jest.fn((requestConfig: InternalAxiosRequestConfig) => {
             // modify the url to one that will respond with status code 200
             return {
                 ...requestConfig,

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,4 +1,4 @@
-import { AxiosError, AxiosInstance, AxiosRequestConfig } from 'axios';
+import { AxiosError, AxiosInstance, InternalAxiosRequestConfig } from 'axios';
 
 export interface AxiosAuthRefreshOptions {
     statusCodes?: Array<number>;
@@ -11,7 +11,9 @@ export interface AxiosAuthRefreshOptions {
     retryInstance?: AxiosInstance;
     interceptNetworkError?: boolean;
     pauseInstanceWhileRefreshing?: boolean;
-    onRetry?: (requestConfig: AxiosRequestConfig) => AxiosRequestConfig | Promise<AxiosRequestConfig>;
+    onRetry?: (
+        requestConfig: InternalAxiosRequestConfig
+    ) => InternalAxiosRequestConfig | Promise<InternalAxiosRequestConfig>;
 
     /**
      * @deprecated
@@ -27,6 +29,6 @@ export interface AxiosAuthRefreshCache {
     requestQueueInterceptorId: number | undefined;
 }
 
-export interface AxiosAuthRefreshRequestConfig extends AxiosRequestConfig {
+export interface AxiosAuthRefreshRequestConfig extends InternalAxiosRequestConfig {
     skipAuthRefresh?: boolean;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
-import axios, { AxiosInstance, AxiosPromise, AxiosRequestConfig } from 'axios';
+import axios, { AxiosInstance, AxiosPromise, InternalAxiosRequestConfig } from 'axios';
 import { AxiosAuthRefreshOptions, AxiosAuthRefreshCache } from './model';
 
-export interface CustomAxiosRequestConfig extends AxiosRequestConfig {
+export interface CustomAxiosRequestConfig extends InternalAxiosRequestConfig {
     skipAuthRefresh?: boolean;
 }
 


### PR DESCRIPTION
It seems that never versions of axios require a different type to be used for interceptors, so I replaced them all.
Interestingly the resulting JS is the same as before.

The `@types/node` update was neccessary due to AbortSIgnal not working otherwise when compiling this on lates LTS version of NodeJS. Mabye this needs an `engine` entry too to only allow more modern versions?

I do not expect this PR to be accepted, but maybe some parts can be used for an upgrade.