### PR TITLE
Patch for xior response interceptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,20 +88,6 @@ To do this, you need to pass the `skipAuthRefresh` option to the request config 
 xior.get('https://www.example.com/', { skipAuthRefresh: true });
 ```
 
-##### Typescript Usage
-
-You need to patch your types with a module declaration in your project:
-
-```
-declare module 'xior' {
-    interface XiorRequestConfig {
-        skipAuthRefresh?: boolean;
-    }
-}
-```
-
-This will solve the `skipAuthRefresh` not being a recognised property.
-
 #### Request interceptor
 
 Since this plugin automatically stalls additional requests while refreshing the token,

--- a/README.md
+++ b/README.md
@@ -88,6 +88,20 @@ To do this, you need to pass the `skipAuthRefresh` option to the request config 
 xior.get('https://www.example.com/', { skipAuthRefresh: true });
 ```
 
+##### Typescript Usage
+
+You need to patch your types with a module declaration in your project:
+
+```
+declare module 'xior' {
+    interface XiorRequestConfig {
+        skipAuthRefresh?: boolean;
+    }
+}
+```
+
+This will solve the `skipAuthRefresh` not being a recognised property.
+
 #### Request interceptor
 
 Since this plugin automatically stalls additional requests while refreshing the token,

--- a/README.md
+++ b/README.md
@@ -88,12 +88,6 @@ To do this, you need to pass the `skipAuthRefresh` option to the request config 
 xior.get('https://www.example.com/', { skipAuthRefresh: true });
 ```
 
-If you're using TypeScript you can import the custom request config interface from `xior-auth-refresh`.
-
-```typescript
-import { XiorAuthRefreshRequestConfig } from 'xior-auth-refresh';
-```
-
 #### Request interceptor
 
 Since this plugin automatically stalls additional requests while refreshing the token,

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
-![Package version](https://img.shields.io/npm/v/axios-auth-refresh?label=version)
-![Package size](https://img.shields.io/bundlephobia/min/axios-auth-refresh)
-![Package downloads](https://img.shields.io/npm/dm/axios-auth-refresh)
-![Package types definitions](https://img.shields.io/npm/types/axios-auth-refresh)
+![Package version](https://img.shields.io/npm/v/xior-auth-refresh?label=version)
+![Package size](https://img.shields.io/bundlephobia/min/xior-auth-refresh)
+![Package downloads](https://img.shields.io/npm/dm/xior-auth-refresh)
+![Package types definitions](https://img.shields.io/npm/types/xior-auth-refresh)
 
-# axios-auth-refresh
+# xior-auth-refresh
+
+This library is a fork of the brilliant [axios-auth-refresh](https://github.com/Flyrell/axios-auth-refresh) library by Dawid Zbiński.
 
 Library that helps you implement automatic refresh of authorization
-via axios [interceptors](https://github.com/axios/axios#interceptors).
+via xior [interceptors](https://github.com/suhaotian/xior?tab=readme-ov-file#using-interceptors).
 You can easily intercept the original request when it fails, refresh the authorization and continue with the original request,
 without any user interaction.
 
@@ -21,79 +23,75 @@ and resolves them when a new token is available.
 Using [npm](https://www.npmjs.com/get-npm) or [yarn](https://yarnpkg.com/en/docs/install):
 
 ```bash
-npm install axios-auth-refresh --save
+npm install xior-auth-refresh --save
 # or
-yarn add axios-auth-refresh
+yarn add xior-auth-refresh
 ```
 
 ## Syntax
 
 ```typescript
 createAuthRefreshInterceptor(
-    axios: AxiosInstance,
+    xior: XiorInstance,
     refreshAuthLogic: (failedRequest: any) => Promise<any>,
-    options: AxiosAuthRefreshOptions = {}
+    options: XiorAuthRefreshOptions = {}
 ): number;
 ```
 
 #### Parameters
 
--   `axios` - an instance of Axios
+-   `xior` - an instance of Xior
 -   `refreshAuthLogic` - a Function used for refreshing authorization (**must return a promise**).
     Accepts exactly one parameter, which is the `failedRequest` returned by the original call.
 -   `options` - object with settings for interceptor (See [available options](#available-options))
 
 #### Returns
 
-Interceptor `id` in case you want to reject it manually.
+Interceptor anonymous function.
 
 ## Usage
 
-In order to activate the interceptors, you need to import a function from `axios-auth-refresh`
-which is _exported by default_ and call it with the **axios instance** you want the interceptors for,
+In order to activate the interceptors, you need to import a function from `xiorf-auth-refresh`
+which is _exported by default_ and call it with the **xior instance** you want the interceptors for,
 as well as the **refresh authorization function** where you need to write the logic for refreshing the authorization.
 
-The interceptors will then be bound onto the axios instance, and the specified logic will be run whenever a [401 (Unauthorized)](https://httpstatuses.com/401) status code
+The interceptors will then be bound onto the xior instance, and the specified logic will be run whenever a [401 (Unauthorized)](https://httpstatuses.com/401) status code
 is returned from a server (or any other status code you provide in options). All the new requests created while the refreshAuthLogic has been processing will be bound onto the
 Promise returned from the refreshAuthLogic function. This means that the requests will be resolved when a new access token has been fetched or when the refreshing logic failed.
 
 ```javascript
-import axios from 'axios';
-import createAuthRefreshInterceptor from 'axios-auth-refresh';
+import xior from 'xior';
+import createAuthRefreshInterceptor from 'xior-auth-refresh';
 
 // Function that will be called to refresh authorization
 const refreshAuthLogic = (failedRequest) =>
-    axios.post('https://www.example.com/auth/token/refresh').then((tokenRefreshResponse) => {
+    xior.post('https://www.example.com/auth/token/refresh').then((tokenRefreshResponse) => {
         localStorage.setItem('token', tokenRefreshResponse.data.token);
         failedRequest.response.config.headers['Authorization'] = 'Bearer ' + tokenRefreshResponse.data.token;
         return Promise.resolve();
     });
 
 // Instantiate the interceptor
-createAuthRefreshInterceptor(axios, refreshAuthLogic);
+createAuthRefreshInterceptor(xior, refreshAuthLogic);
 
 // Make a call. If it returns a 401 error, the refreshAuthLogic will be run,
 // and the request retried with the new token
-axios.get('https://www.example.com/restricted/area').then(/* ... */).catch(/* ... */);
+xior.get('https://www.example.com/restricted/area').then(/* ... */).catch(/* ... */);
 ```
 
 #### Skipping the interceptor
-
-:warning: Because of the bug [axios#2295](https://github.com/axios/axios/issues/2295) v0.19.0 is not supported. :warning:
-
-:white_check_mark: This has been fixed and will be released in axios v0.19.1
 
 There's a possibility to skip the logic of the interceptor for specific calls.
 To do this, you need to pass the `skipAuthRefresh` option to the request config for each request you don't want to intercept.
 
 ```javascript
-axios.get('https://www.example.com/', { skipAuthRefresh: true });
+xior.get('https://www.example.com/', { skipAuthRefresh: true });
 ```
 
-If you're using TypeScript you can import the custom request config interface from `axios-auth-refresh`.
+If you're using TypeScript you can import the custom request config interface from `xior-auth-refresh`.
 
 ```typescript
-import { AxiosAuthRefreshRequestConfig } from 'axios-auth-refresh';
+import { XiorAuthRefreshRequestConfig } from 'xior-auth-refresh';
 ```
 
 #### Request interceptor
@@ -111,7 +109,7 @@ function getAccessToken() {
 }
 
 // Use interceptor to inject the token to requests
-axios.interceptors.request.use((request) => {
+xior.interceptors.request.use((request) => {
     request.headers['Authorization'] = `Bearer ${getAccessToken()}`;
     return request;
 });
@@ -147,7 +145,7 @@ Default value is `undefined` and the instance passed to `createAuthRefreshInterc
 
 ```javascript
 {
-    retryInstance: someAxiosInstance, // default: undefined
+    retryInstance: someXiorInstance, // default: undefined
 }
 ```
 
@@ -172,7 +170,7 @@ codes specified in `options.statusCodes`) you need to use a [`skipAuthRefresh`](
 flag on your refreshing call inside the `refreshAuthLogic` function.
 
 In case your refresh logic does not make any calls, you should consider using the following flag
-when initializing the interceptor to pause the whole axios instance while the refreshing is pending.
+when initializing the interceptor to pause the whole xior instance while the refreshing is pending.
 This prevents interceptor from running for each failed request.
 
 ```javascript
@@ -196,37 +194,3 @@ with an HTTP 401 response, your retry logic can test for network connectivity at
     interceptNetworkError: true, // default: undefined
 }
 ```
-
-### Other usages of the library
-
-This library has also been used for:
-
--   Automatic request throttling by [@amcsi](https://github.com/amcsi)
--   OTP challenges with Google2FA by [@LeoniePhiline](https://github.com/LeoniePhiline)
-
-have you used it for something else? Create a PR with your use case to share it.
-
----
-
-### Changelog
-
--   **v3.1.0**
-
-    -   axios v0.21.1 support
-    -   `interceptNetworkError` option introduced. See [#133](https://github.com/Flyrell/axios-auth-refresh/issues/133).
-
--   **v3.0.0**
-    -   `skipWhileRefresh` flag has been deprecated due to its unclear name and its logic has been moved to `pauseInstanceWhileRefreshing` flag
-    -   `pauseInstanceWhileRefreshing` is set to `false` by default
-
----
-
-#### Want to help?
-
-Check out [contribution guide](CONTRIBUTING.md) or my [patreon page!](https://www.patreon.com/dawidzbinski)
-
----
-
-#### Special thanks to [JetBrains](https://www.jetbrains.com/?from=axios-auth-refresh) for providing the IDE for our library
-
-<a href="https://www.jetbrains.com/?from=axios-auth-refresh" title="Link to JetBrains"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/1a/JetBrains_Logo_2016.svg/128px-JetBrains_Logo_2016.svg.png" alt="JetBrains"></a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mgoodfellow/xior-auth-refresh",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@mgoodfellow/xior-auth-refresh",
-            "version": "0.0.1",
+            "version": "0.0.2",
             "license": "MIT",
             "devDependencies": {
                 "@types/jest": "^28.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "@mgoodfellow/xior-auth-refresh",
+    "name": "xior-auth-refresh",
     "version": "0.0.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "@mgoodfellow/xior-auth-refresh",
+            "name": "xior-auth-refresh",
             "version": "0.0.3",
             "license": "MIT",
             "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "devDependencies": {
                 "@types/jest": "^28.1.6",
                 "babel-loader": "^9.1.0",
+                "bunchee": "^5.1.2",
                 "clean-webpack-plugin": "^4.0.0",
                 "declaration-bundler-webpack-plugin": "^1.0.3",
                 "husky": "^8.0.1",
@@ -531,6 +532,12 @@
             "engines": {
                 "node": ">=10.0.0"
             }
+        },
+        "node_modules/@fastify/deepmerge": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-1.3.0.tgz",
+            "integrity": "sha512-J8TOSBq3SoZbDhM9+R/u77hP93gz/rajSA+K2kGyijPpORPWUXHUpTaleoj+92As0S9uPRP7Oi8IqMf0u+ro6A==",
+            "dev": true
         },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
@@ -1257,9 +1264,9 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.4.14",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+            "version": "1.4.15",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
             "dev": true
         },
         "node_modules/@jridgewell/trace-mapping": {
@@ -1271,6 +1278,393 @@
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
+        },
+        "node_modules/@rollup/plugin-commonjs": {
+            "version": "25.0.7",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.7.tgz",
+            "integrity": "sha512-nEvcR+LRjEjsaSsc4x3XZfCCvZIaSMenZu/OiwOKGN2UhQpAYI7ru7czFvyWbErlpoGjnSX3D5Ch5FcMA3kRWQ==",
+            "dev": true,
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "commondir": "^1.0.1",
+                "estree-walker": "^2.0.2",
+                "glob": "^8.0.3",
+                "is-reference": "1.2.1",
+                "magic-string": "^0.30.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^2.68.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-commonjs/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@rollup/plugin-commonjs/node_modules/glob": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^5.0.1",
+                "once": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@rollup/plugin-commonjs/node_modules/minimatch": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@rollup/plugin-json": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
+            "integrity": "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==",
+            "dev": true,
+            "dependencies": {
+                "@rollup/pluginutils": "^5.1.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-node-resolve": {
+            "version": "15.2.3",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.3.tgz",
+            "integrity": "sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==",
+            "dev": true,
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "@types/resolve": "1.20.2",
+                "deepmerge": "^4.2.2",
+                "is-builtin-module": "^3.2.1",
+                "is-module": "^1.0.0",
+                "resolve": "^1.22.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^2.78.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-replace": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-5.0.5.tgz",
+            "integrity": "sha512-rYO4fOi8lMaTg/z5Jb+hKnrHHVn8j2lwkqwyS4kTRhKyWOLf2wST2sWXr4WzWiTcoHTp2sTjqUbqIj2E39slKQ==",
+            "dev": true,
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "magic-string": "^0.30.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-wasm": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-wasm/-/plugin-wasm-6.2.2.tgz",
+            "integrity": "sha512-gpC4R1G9Ni92ZIRTexqbhX7U+9estZrbhP+9SRb0DW9xpB9g7j34r+J2hqrcW/lRI7dJaU84MxZM0Rt82tqYPQ==",
+            "dev": true,
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/pluginutils": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+            "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "^1.0.0",
+                "estree-walker": "^2.0.2",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/pluginutils/node_modules/@types/estree": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+            "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+            "dev": true
+        },
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.14.3.tgz",
+            "integrity": "sha512-X9alQ3XM6I9IlSlmC8ddAvMSyG1WuHk5oUnXGw+yUBs3BFoTizmG1La/Gr8fVJvDWAq+zlYTZ9DBgrlKRVY06g==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.14.3.tgz",
+            "integrity": "sha512-eQK5JIi+POhFpzk+LnjKIy4Ks+pwJ+NXmPxOCSvOKSNRPONzKuUvWE+P9JxGZVxrtzm6BAYMaL50FFuPe0oWMQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.14.3.tgz",
+            "integrity": "sha512-Od4vE6f6CTT53yM1jgcLqNfItTsLt5zE46fdPaEmeFHvPs5SjZYlLpHrSiHEKR1+HdRfxuzXHjDOIxQyC3ptBA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.14.3.tgz",
+            "integrity": "sha512-0IMAO21axJeNIrvS9lSe/PGthc8ZUS+zC53O0VhF5gMxfmcKAP4ESkKOCwEi6u2asUrt4mQv2rjY8QseIEb1aw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.14.3.tgz",
+            "integrity": "sha512-ge2DC7tHRHa3caVEoSbPRJpq7azhG+xYsd6u2MEnJ6XzPSzQsTKyXvh6iWjXRf7Rt9ykIUWHtl0Uz3T6yXPpKw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.14.3.tgz",
+            "integrity": "sha512-ljcuiDI4V3ySuc7eSk4lQ9wU8J8r8KrOUvB2U+TtK0TiW6OFDmJ+DdIjjwZHIw9CNxzbmXY39wwpzYuFDwNXuw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.14.3.tgz",
+            "integrity": "sha512-Eci2us9VTHm1eSyn5/eEpaC7eP/mp5n46gTRB3Aar3BgSvDQGJZuicyq6TsH4HngNBgVqC5sDYxOzTExSU+NjA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.14.3.tgz",
+            "integrity": "sha512-UrBoMLCq4E92/LCqlh+blpqMz5h1tJttPIniwUgOFJyjWI1qrtrDhhpHPuFxULlUmjFHfloWdixtDhSxJt5iKw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.14.3.tgz",
+            "integrity": "sha512-5aRjvsS8q1nWN8AoRfrq5+9IflC3P1leMoy4r2WjXyFqf3qcqsxRCfxtZIV58tCxd+Yv7WELPcO9mY9aeQyAmw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.14.3.tgz",
+            "integrity": "sha512-sk/Qh1j2/RJSX7FhEpJn8n0ndxy/uf0kI/9Zc4b1ELhqULVdTfN6HL31CDaTChiBAOgLcsJ1sgVZjWv8XNEsAQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.14.3.tgz",
+            "integrity": "sha512-jOO/PEaDitOmY9TgkxF/TQIjXySQe5KVYB57H/8LRP/ux0ZoO8cSHCX17asMSv3ruwslXW/TLBcxyaUzGRHcqg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.14.3.tgz",
+            "integrity": "sha512-8ybV4Xjy59xLMyWo3GCfEGqtKV5M5gCSrZlxkPGvEPCGDLNla7v48S662HSGwRd6/2cSneMQWiv+QzcttLrrOA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.14.3.tgz",
+            "integrity": "sha512-s+xf1I46trOY10OqAtZ5Rm6lzHre/UiLA1J2uOhCFXWkbZrJRkYBPO6FhvGfHmdtQ3Bx793MNa7LvoWFAm93bg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.14.3.tgz",
+            "integrity": "sha512-+4h2WrGOYsOumDQ5S2sYNyhVfrue+9tc9XcLWLh+Kw3UOxAvrfOrSMFon60KspcDdytkNDh7K2Vs6eMaYImAZg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.14.3.tgz",
+            "integrity": "sha512-T1l7y/bCeL/kUwh9OD4PQT4aM7Bq43vX05htPJJ46RTI4r5KNt6qJRzAfNfM+OYMNEVBWQzR2Gyk+FXLZfogGw==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.14.3.tgz",
+            "integrity": "sha512-/BypzV0H1y1HzgYpxqRaXGBRqfodgoBBCcsrujT6QRcakDQdfU+Lq9PENPh5jB4I44YWq+0C2eHsHya+nZY1sA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ]
         },
         "node_modules/@sinclair/typebox": {
             "version": "0.24.44",
@@ -1294,6 +1688,228 @@
             "dev": true,
             "dependencies": {
                 "@sinonjs/commons": "^1.7.0"
+            }
+        },
+        "node_modules/@swc/core": {
+            "version": "1.4.16",
+            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.4.16.tgz",
+            "integrity": "sha512-Xaf+UBvW6JNuV131uvSNyMXHn+bh6LyKN4tbv7tOUFQpXyz/t9YWRE04emtlUW9Y0qrm/GKFCbY8n3z6BpZbTA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "dependencies": {
+                "@swc/counter": "^0.1.2",
+                "@swc/types": "^0.1.5"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/swc"
+            },
+            "optionalDependencies": {
+                "@swc/core-darwin-arm64": "1.4.16",
+                "@swc/core-darwin-x64": "1.4.16",
+                "@swc/core-linux-arm-gnueabihf": "1.4.16",
+                "@swc/core-linux-arm64-gnu": "1.4.16",
+                "@swc/core-linux-arm64-musl": "1.4.16",
+                "@swc/core-linux-x64-gnu": "1.4.16",
+                "@swc/core-linux-x64-musl": "1.4.16",
+                "@swc/core-win32-arm64-msvc": "1.4.16",
+                "@swc/core-win32-ia32-msvc": "1.4.16",
+                "@swc/core-win32-x64-msvc": "1.4.16"
+            },
+            "peerDependencies": {
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependenciesMeta": {
+                "@swc/helpers": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@swc/core-darwin-arm64": {
+            "version": "1.4.16",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.4.16.tgz",
+            "integrity": "sha512-UOCcH1GvjRnnM/LWT6VCGpIk0OhHRq6v1U6QXuPt5wVsgXnXQwnf5k3sG5Cm56hQHDvhRPY6HCsHi/p0oek8oQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-darwin-x64": {
+            "version": "1.4.16",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.4.16.tgz",
+            "integrity": "sha512-t3bgqFoYLWvyVtVL6KkFNCINEoOrIlyggT/kJRgi1y0aXSr0oVgcrQ4ezJpdeahZZ4N+Q6vT3ffM30yIunELNA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm-gnueabihf": {
+            "version": "1.4.16",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.4.16.tgz",
+            "integrity": "sha512-DvHuwvEF86YvSd0lwnzVcjOTZ0jcxewIbsN0vc/0fqm9qBdMMjr9ox6VCam1n3yYeRtj4VFgrjeNFksqbUejdQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm64-gnu": {
+            "version": "1.4.16",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.4.16.tgz",
+            "integrity": "sha512-9Uu5YlPbyCvbidjKtYEsPpyZlu16roOZ5c2tP1vHfnU9bgf5Tz5q5VovSduNxPHx+ed2iC1b1URODHvDzbbDuQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm64-musl": {
+            "version": "1.4.16",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.4.16.tgz",
+            "integrity": "sha512-/YZq/qB1CHpeoL0eMzyqK5/tYZn/rzKoCYDviFU4uduSUIJsDJQuQA/skdqUzqbheOXKAd4mnJ1hT04RbJ8FPQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-x64-gnu": {
+            "version": "1.4.16",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.4.16.tgz",
+            "integrity": "sha512-UUjaW5VTngZYDcA8yQlrFmqs1tLi1TxbKlnaJwoNhel9zRQ0yG1YEVGrzTvv4YApSuIiDK18t+Ip927bwucuVQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-x64-musl": {
+            "version": "1.4.16",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.4.16.tgz",
+            "integrity": "sha512-aFhxPifevDTwEDKPi4eRYWzC0p/WYJeiFkkpNU5Uc7a7M5iMWPAbPFUbHesdlb9Jfqs5c07oyz86u+/HySBNPQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-arm64-msvc": {
+            "version": "1.4.16",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.4.16.tgz",
+            "integrity": "sha512-bTD43MbhIHL2s5QgCwyleaGwl96Gk/scF2TaVKdUe4QlJCDV/YK9h5oIBAp63ckHtE8GHlH4c8dZNBiAXn4Org==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-ia32-msvc": {
+            "version": "1.4.16",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.4.16.tgz",
+            "integrity": "sha512-/lmZeAN/qV5XbK2SEvi8e2RkIg8FQNYiSA8y2/Zb4gTUMKVO5JMLH0BSWMiIKMstKDPDSxMWgwJaQHF8UMyPmQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-x64-msvc": {
+            "version": "1.4.16",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.4.16.tgz",
+            "integrity": "sha512-BPAfFfODWXtUu6SwaTTftDHvcbDyWBSI/oanUeRbQR5vVWkXoQ3cxLTsDluc3H74IqXS5z1Uyoe0vNo2hB1opA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/counter": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+            "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+            "dev": true
+        },
+        "node_modules/@swc/helpers": {
+            "version": "0.5.10",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.10.tgz",
+            "integrity": "sha512-CU+RF9FySljn7HVSkkjiB84hWkvTaI3rtLvF433+jRSBL2hMu3zX5bGhHS8C80SM++h4xy8hBSnUHFQHmRXSBw==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@swc/types": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.6.tgz",
+            "integrity": "sha512-/JLo/l2JsT/LRd80C3HfbmVpxOAJ11FO2RCEslFrgzLltoP9j8XIbsyDcfCt2WWyX+CM96rBoNM+IToAkFOugg==",
+            "dev": true,
+            "dependencies": {
+                "@swc/counter": "^0.1.3"
             }
         },
         "node_modules/@types/babel__core": {
@@ -1429,15 +2045,24 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "18.8.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.2.tgz",
-            "integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA==",
-            "dev": true
+            "version": "20.12.7",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
+            "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
         },
         "node_modules/@types/prettier": {
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
             "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
+            "dev": true
+        },
+        "node_modules/@types/resolve": {
+            "version": "1.20.2",
+            "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+            "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
             "dev": true
         },
         "node_modules/@types/stack-utils": {
@@ -1797,6 +2422,12 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/arg": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+            "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+            "dev": true
+        },
         "node_modules/argparse": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -2106,6 +2737,60 @@
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "dev": true
         },
+        "node_modules/builtin-modules": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+            "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/bunchee": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/bunchee/-/bunchee-5.1.2.tgz",
+            "integrity": "sha512-fOcub+z6CcCesKjVX82+B6wPTzQjtcHjrI1zcAc/acc5PRmI4fNsww7p20VxR8lctaXPrLnbuWeuhtSrZ311/Q==",
+            "dev": true,
+            "dependencies": {
+                "@rollup/plugin-commonjs": "^25.0.7",
+                "@rollup/plugin-json": "^6.1.0",
+                "@rollup/plugin-node-resolve": "^15.2.3",
+                "@rollup/plugin-replace": "^5.0.5",
+                "@rollup/plugin-wasm": "^6.2.2",
+                "@rollup/pluginutils": "^5.1.0",
+                "@swc/core": "^1.4.8",
+                "@swc/helpers": "^0.5.6",
+                "arg": "^5.0.2",
+                "clean-css": "^5.3.3",
+                "magic-string": "^0.30.8",
+                "pretty-bytes": "^5.6.0",
+                "rollup": "^4.13.0",
+                "rollup-plugin-dts": "^6.1.0",
+                "rollup-plugin-swc3": "^0.11.0",
+                "rollup-preserve-directives": "^1.1.1",
+                "tslib": "^2.6.2"
+            },
+            "bin": {
+                "bunchee": "dist/bin/cli.js"
+            },
+            "engines": {
+                "node": ">= 18.0.0"
+            },
+            "peerDependencies": {
+                "typescript": "^4.1 || ^5.0"
+            },
+            "peerDependenciesMeta": {
+                "@swc/helpers": {
+                    "optional": true
+                },
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2183,6 +2868,18 @@
             "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
             "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
             "dev": true
+        },
+        "node_modules/clean-css": {
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
+            "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
+            "dev": true,
+            "dependencies": {
+                "source-map": "~0.6.0"
+            },
+            "engines": {
+                "node": ">= 10.0"
+            }
         },
         "node_modules/clean-webpack-plugin": {
             "version": "4.0.0",
@@ -2526,6 +3223,12 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true
+        },
         "node_modules/events": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -2720,6 +3423,18 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/get-tsconfig": {
+            "version": "4.7.3",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.3.tgz",
+            "integrity": "sha512-ZvkrzoUA0PQZM6fy6+/Hce561s+faD1rsNwhnO5FelNjyy7EMGJ3Rz1AQ8GYDWjhRs/7dBLOEJvhK8MiEJOAFg==",
+            "dev": true,
+            "dependencies": {
+                "resolve-pkg-maps": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+            }
+        },
         "node_modules/glob": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -2905,6 +3620,21 @@
             "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
             "dev": true
         },
+        "node_modules/is-builtin-module": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+            "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+            "dev": true,
+            "dependencies": {
+                "builtin-modules": "^3.3.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-core-module": {
             "version": "2.10.0",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
@@ -2934,6 +3664,12 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/is-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+            "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+            "dev": true
         },
         "node_modules/is-number": {
             "version": "7.0.0",
@@ -2987,6 +3723,15 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-reference": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+            "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "*"
             }
         },
         "node_modules/is-stream": {
@@ -4789,6 +5534,15 @@
                 "node": ">=10"
             }
         },
+        "node_modules/magic-string": {
+            "version": "0.30.10",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
+            "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.4.15"
+            }
+        },
         "node_modules/make-dir": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -5205,6 +5959,18 @@
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
+        "node_modules/pretty-bytes": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+            "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/pretty-format": {
             "version": "28.1.3",
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz",
@@ -5484,6 +6250,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/resolve-pkg-maps": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+            "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+            }
+        },
         "node_modules/resolve.exports": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz",
@@ -5504,6 +6279,100 @@
             "bin": {
                 "rimraf": "bin.js"
             }
+        },
+        "node_modules/rollup": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.3.tgz",
+            "integrity": "sha512-ag5tTQKYsj1bhrFC9+OEWqb5O6VYgtQDO9hPDBMmIbePwhfSr+ExlcU741t8Dhw5DkPCQf6noz0jb36D6W9/hw==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "1.0.5"
+            },
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "npm": ">=8.0.0"
+            },
+            "optionalDependencies": {
+                "@rollup/rollup-android-arm-eabi": "4.14.3",
+                "@rollup/rollup-android-arm64": "4.14.3",
+                "@rollup/rollup-darwin-arm64": "4.14.3",
+                "@rollup/rollup-darwin-x64": "4.14.3",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.14.3",
+                "@rollup/rollup-linux-arm-musleabihf": "4.14.3",
+                "@rollup/rollup-linux-arm64-gnu": "4.14.3",
+                "@rollup/rollup-linux-arm64-musl": "4.14.3",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.14.3",
+                "@rollup/rollup-linux-riscv64-gnu": "4.14.3",
+                "@rollup/rollup-linux-s390x-gnu": "4.14.3",
+                "@rollup/rollup-linux-x64-gnu": "4.14.3",
+                "@rollup/rollup-linux-x64-musl": "4.14.3",
+                "@rollup/rollup-win32-arm64-msvc": "4.14.3",
+                "@rollup/rollup-win32-ia32-msvc": "4.14.3",
+                "@rollup/rollup-win32-x64-msvc": "4.14.3",
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/rollup-plugin-dts": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-6.1.0.tgz",
+            "integrity": "sha512-ijSCPICkRMDKDLBK9torss07+8dl9UpY9z1N/zTeA1cIqdzMlpkV3MOOC7zukyvQfDyxa1s3Dl2+DeiP/G6DOw==",
+            "dev": true,
+            "dependencies": {
+                "magic-string": "^0.30.4"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/Swatinem"
+            },
+            "optionalDependencies": {
+                "@babel/code-frame": "^7.22.13"
+            },
+            "peerDependencies": {
+                "rollup": "^3.29.4 || ^4",
+                "typescript": "^4.5 || ^5.0"
+            }
+        },
+        "node_modules/rollup-plugin-swc3": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-swc3/-/rollup-plugin-swc3-0.11.1.tgz",
+            "integrity": "sha512-6j8kWS6HM63P9pc6O5UtfhZkW9vVmkYfoEmZxR3Nua6KQRDCM3a6RrskqiGeiCnJ9s1W+tAmlVYz80G9yy2/Kg==",
+            "dev": true,
+            "dependencies": {
+                "@fastify/deepmerge": "^1.3.0",
+                "@rollup/pluginutils": "^5.1.0",
+                "get-tsconfig": "^4.7.3",
+                "rollup-preserve-directives": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "@swc/core": ">=1.2.165",
+                "rollup": "^2.0.0 || ^3.0.0 || ^4.0.0"
+            }
+        },
+        "node_modules/rollup-preserve-directives": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/rollup-preserve-directives/-/rollup-preserve-directives-1.1.1.tgz",
+            "integrity": "sha512-+eQafbuEfDPfxQ9hQPlwaROfin4yiVRxap8hnrvvvcSGoukv1tTiYpAW9mvm3uR8J+fe4xd8FdVd5rz9q7jZ+Q==",
+            "dev": true,
+            "dependencies": {
+                "magic-string": "^0.30.5"
+            },
+            "peerDependencies": {
+                "rollup": "^2.0.0 || ^3.0.0 || ^4.0.0"
+            }
+        },
+        "node_modules/rollup/node_modules/@types/estree": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+            "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+            "dev": true
         },
         "node_modules/safe-buffer": {
             "version": "5.1.2",
@@ -6173,6 +7042,12 @@
                 "node": ">=8"
             }
         },
+        "node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+            "dev": true
+        },
         "node_modules/type-detect": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -6206,6 +7081,12 @@
             "engines": {
                 "node": ">=4.2.0"
             }
+        },
+        "node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "dev": true
         },
         "node_modules/update-browserslist-db": {
             "version": "1.0.9",
@@ -6950,6 +7831,12 @@
             "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
             "dev": true
         },
+        "@fastify/deepmerge": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-1.3.0.tgz",
+            "integrity": "sha512-J8TOSBq3SoZbDhM9+R/u77hP93gz/rajSA+K2kGyijPpORPWUXHUpTaleoj+92As0S9uPRP7Oi8IqMf0u+ro6A==",
+            "dev": true
+        },
         "@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -7500,9 +8387,9 @@
             }
         },
         "@jridgewell/sourcemap-codec": {
-            "version": "1.4.14",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+            "version": "1.4.15",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
             "dev": true
         },
         "@jridgewell/trace-mapping": {
@@ -7514,6 +8401,226 @@
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
+        },
+        "@rollup/plugin-commonjs": {
+            "version": "25.0.7",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.7.tgz",
+            "integrity": "sha512-nEvcR+LRjEjsaSsc4x3XZfCCvZIaSMenZu/OiwOKGN2UhQpAYI7ru7czFvyWbErlpoGjnSX3D5Ch5FcMA3kRWQ==",
+            "dev": true,
+            "requires": {
+                "@rollup/pluginutils": "^5.0.1",
+                "commondir": "^1.0.1",
+                "estree-walker": "^2.0.2",
+                "glob": "^8.0.3",
+                "is-reference": "1.2.1",
+                "magic-string": "^0.30.3"
+            },
+            "dependencies": {
+                "brace-expansion": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+                    "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0"
+                    }
+                },
+                "glob": {
+                    "version": "8.1.0",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+                    "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^5.0.1",
+                        "once": "^1.3.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "5.1.6",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+                    "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^2.0.1"
+                    }
+                }
+            }
+        },
+        "@rollup/plugin-json": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
+            "integrity": "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==",
+            "dev": true,
+            "requires": {
+                "@rollup/pluginutils": "^5.1.0"
+            }
+        },
+        "@rollup/plugin-node-resolve": {
+            "version": "15.2.3",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.3.tgz",
+            "integrity": "sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==",
+            "dev": true,
+            "requires": {
+                "@rollup/pluginutils": "^5.0.1",
+                "@types/resolve": "1.20.2",
+                "deepmerge": "^4.2.2",
+                "is-builtin-module": "^3.2.1",
+                "is-module": "^1.0.0",
+                "resolve": "^1.22.1"
+            }
+        },
+        "@rollup/plugin-replace": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-5.0.5.tgz",
+            "integrity": "sha512-rYO4fOi8lMaTg/z5Jb+hKnrHHVn8j2lwkqwyS4kTRhKyWOLf2wST2sWXr4WzWiTcoHTp2sTjqUbqIj2E39slKQ==",
+            "dev": true,
+            "requires": {
+                "@rollup/pluginutils": "^5.0.1",
+                "magic-string": "^0.30.3"
+            }
+        },
+        "@rollup/plugin-wasm": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-wasm/-/plugin-wasm-6.2.2.tgz",
+            "integrity": "sha512-gpC4R1G9Ni92ZIRTexqbhX7U+9estZrbhP+9SRb0DW9xpB9g7j34r+J2hqrcW/lRI7dJaU84MxZM0Rt82tqYPQ==",
+            "dev": true,
+            "requires": {
+                "@rollup/pluginutils": "^5.0.2"
+            }
+        },
+        "@rollup/pluginutils": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+            "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
+            "dev": true,
+            "requires": {
+                "@types/estree": "^1.0.0",
+                "estree-walker": "^2.0.2",
+                "picomatch": "^2.3.1"
+            },
+            "dependencies": {
+                "@types/estree": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+                    "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+                    "dev": true
+                }
+            }
+        },
+        "@rollup/rollup-android-arm-eabi": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.14.3.tgz",
+            "integrity": "sha512-X9alQ3XM6I9IlSlmC8ddAvMSyG1WuHk5oUnXGw+yUBs3BFoTizmG1La/Gr8fVJvDWAq+zlYTZ9DBgrlKRVY06g==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-android-arm64": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.14.3.tgz",
+            "integrity": "sha512-eQK5JIi+POhFpzk+LnjKIy4Ks+pwJ+NXmPxOCSvOKSNRPONzKuUvWE+P9JxGZVxrtzm6BAYMaL50FFuPe0oWMQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-darwin-arm64": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.14.3.tgz",
+            "integrity": "sha512-Od4vE6f6CTT53yM1jgcLqNfItTsLt5zE46fdPaEmeFHvPs5SjZYlLpHrSiHEKR1+HdRfxuzXHjDOIxQyC3ptBA==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-darwin-x64": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.14.3.tgz",
+            "integrity": "sha512-0IMAO21axJeNIrvS9lSe/PGthc8ZUS+zC53O0VhF5gMxfmcKAP4ESkKOCwEi6u2asUrt4mQv2rjY8QseIEb1aw==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.14.3.tgz",
+            "integrity": "sha512-ge2DC7tHRHa3caVEoSbPRJpq7azhG+xYsd6u2MEnJ6XzPSzQsTKyXvh6iWjXRf7Rt9ykIUWHtl0Uz3T6yXPpKw==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-linux-arm-musleabihf": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.14.3.tgz",
+            "integrity": "sha512-ljcuiDI4V3ySuc7eSk4lQ9wU8J8r8KrOUvB2U+TtK0TiW6OFDmJ+DdIjjwZHIw9CNxzbmXY39wwpzYuFDwNXuw==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.14.3.tgz",
+            "integrity": "sha512-Eci2us9VTHm1eSyn5/eEpaC7eP/mp5n46gTRB3Aar3BgSvDQGJZuicyq6TsH4HngNBgVqC5sDYxOzTExSU+NjA==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-linux-arm64-musl": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.14.3.tgz",
+            "integrity": "sha512-UrBoMLCq4E92/LCqlh+blpqMz5h1tJttPIniwUgOFJyjWI1qrtrDhhpHPuFxULlUmjFHfloWdixtDhSxJt5iKw==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-linux-powerpc64le-gnu": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.14.3.tgz",
+            "integrity": "sha512-5aRjvsS8q1nWN8AoRfrq5+9IflC3P1leMoy4r2WjXyFqf3qcqsxRCfxtZIV58tCxd+Yv7WELPcO9mY9aeQyAmw==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.14.3.tgz",
+            "integrity": "sha512-sk/Qh1j2/RJSX7FhEpJn8n0ndxy/uf0kI/9Zc4b1ELhqULVdTfN6HL31CDaTChiBAOgLcsJ1sgVZjWv8XNEsAQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.14.3.tgz",
+            "integrity": "sha512-jOO/PEaDitOmY9TgkxF/TQIjXySQe5KVYB57H/8LRP/ux0ZoO8cSHCX17asMSv3ruwslXW/TLBcxyaUzGRHcqg==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-linux-x64-gnu": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.14.3.tgz",
+            "integrity": "sha512-8ybV4Xjy59xLMyWo3GCfEGqtKV5M5gCSrZlxkPGvEPCGDLNla7v48S662HSGwRd6/2cSneMQWiv+QzcttLrrOA==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-linux-x64-musl": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.14.3.tgz",
+            "integrity": "sha512-s+xf1I46trOY10OqAtZ5Rm6lzHre/UiLA1J2uOhCFXWkbZrJRkYBPO6FhvGfHmdtQ3Bx793MNa7LvoWFAm93bg==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.14.3.tgz",
+            "integrity": "sha512-+4h2WrGOYsOumDQ5S2sYNyhVfrue+9tc9XcLWLh+Kw3UOxAvrfOrSMFon60KspcDdytkNDh7K2Vs6eMaYImAZg==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.14.3.tgz",
+            "integrity": "sha512-T1l7y/bCeL/kUwh9OD4PQT4aM7Bq43vX05htPJJ46RTI4r5KNt6qJRzAfNfM+OYMNEVBWQzR2Gyk+FXLZfogGw==",
+            "dev": true,
+            "optional": true
+        },
+        "@rollup/rollup-win32-x64-msvc": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.14.3.tgz",
+            "integrity": "sha512-/BypzV0H1y1HzgYpxqRaXGBRqfodgoBBCcsrujT6QRcakDQdfU+Lq9PENPh5jB4I44YWq+0C2eHsHya+nZY1sA==",
+            "dev": true,
+            "optional": true
         },
         "@sinclair/typebox": {
             "version": "0.24.44",
@@ -7537,6 +8644,120 @@
             "dev": true,
             "requires": {
                 "@sinonjs/commons": "^1.7.0"
+            }
+        },
+        "@swc/core": {
+            "version": "1.4.16",
+            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.4.16.tgz",
+            "integrity": "sha512-Xaf+UBvW6JNuV131uvSNyMXHn+bh6LyKN4tbv7tOUFQpXyz/t9YWRE04emtlUW9Y0qrm/GKFCbY8n3z6BpZbTA==",
+            "dev": true,
+            "requires": {
+                "@swc/core-darwin-arm64": "1.4.16",
+                "@swc/core-darwin-x64": "1.4.16",
+                "@swc/core-linux-arm-gnueabihf": "1.4.16",
+                "@swc/core-linux-arm64-gnu": "1.4.16",
+                "@swc/core-linux-arm64-musl": "1.4.16",
+                "@swc/core-linux-x64-gnu": "1.4.16",
+                "@swc/core-linux-x64-musl": "1.4.16",
+                "@swc/core-win32-arm64-msvc": "1.4.16",
+                "@swc/core-win32-ia32-msvc": "1.4.16",
+                "@swc/core-win32-x64-msvc": "1.4.16",
+                "@swc/counter": "^0.1.2",
+                "@swc/types": "^0.1.5"
+            }
+        },
+        "@swc/core-darwin-arm64": {
+            "version": "1.4.16",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.4.16.tgz",
+            "integrity": "sha512-UOCcH1GvjRnnM/LWT6VCGpIk0OhHRq6v1U6QXuPt5wVsgXnXQwnf5k3sG5Cm56hQHDvhRPY6HCsHi/p0oek8oQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@swc/core-darwin-x64": {
+            "version": "1.4.16",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.4.16.tgz",
+            "integrity": "sha512-t3bgqFoYLWvyVtVL6KkFNCINEoOrIlyggT/kJRgi1y0aXSr0oVgcrQ4ezJpdeahZZ4N+Q6vT3ffM30yIunELNA==",
+            "dev": true,
+            "optional": true
+        },
+        "@swc/core-linux-arm-gnueabihf": {
+            "version": "1.4.16",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.4.16.tgz",
+            "integrity": "sha512-DvHuwvEF86YvSd0lwnzVcjOTZ0jcxewIbsN0vc/0fqm9qBdMMjr9ox6VCam1n3yYeRtj4VFgrjeNFksqbUejdQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@swc/core-linux-arm64-gnu": {
+            "version": "1.4.16",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.4.16.tgz",
+            "integrity": "sha512-9Uu5YlPbyCvbidjKtYEsPpyZlu16roOZ5c2tP1vHfnU9bgf5Tz5q5VovSduNxPHx+ed2iC1b1URODHvDzbbDuQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@swc/core-linux-arm64-musl": {
+            "version": "1.4.16",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.4.16.tgz",
+            "integrity": "sha512-/YZq/qB1CHpeoL0eMzyqK5/tYZn/rzKoCYDviFU4uduSUIJsDJQuQA/skdqUzqbheOXKAd4mnJ1hT04RbJ8FPQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@swc/core-linux-x64-gnu": {
+            "version": "1.4.16",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.4.16.tgz",
+            "integrity": "sha512-UUjaW5VTngZYDcA8yQlrFmqs1tLi1TxbKlnaJwoNhel9zRQ0yG1YEVGrzTvv4YApSuIiDK18t+Ip927bwucuVQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@swc/core-linux-x64-musl": {
+            "version": "1.4.16",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.4.16.tgz",
+            "integrity": "sha512-aFhxPifevDTwEDKPi4eRYWzC0p/WYJeiFkkpNU5Uc7a7M5iMWPAbPFUbHesdlb9Jfqs5c07oyz86u+/HySBNPQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@swc/core-win32-arm64-msvc": {
+            "version": "1.4.16",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.4.16.tgz",
+            "integrity": "sha512-bTD43MbhIHL2s5QgCwyleaGwl96Gk/scF2TaVKdUe4QlJCDV/YK9h5oIBAp63ckHtE8GHlH4c8dZNBiAXn4Org==",
+            "dev": true,
+            "optional": true
+        },
+        "@swc/core-win32-ia32-msvc": {
+            "version": "1.4.16",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.4.16.tgz",
+            "integrity": "sha512-/lmZeAN/qV5XbK2SEvi8e2RkIg8FQNYiSA8y2/Zb4gTUMKVO5JMLH0BSWMiIKMstKDPDSxMWgwJaQHF8UMyPmQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@swc/core-win32-x64-msvc": {
+            "version": "1.4.16",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.4.16.tgz",
+            "integrity": "sha512-BPAfFfODWXtUu6SwaTTftDHvcbDyWBSI/oanUeRbQR5vVWkXoQ3cxLTsDluc3H74IqXS5z1Uyoe0vNo2hB1opA==",
+            "dev": true,
+            "optional": true
+        },
+        "@swc/counter": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+            "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+            "dev": true
+        },
+        "@swc/helpers": {
+            "version": "0.5.10",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.10.tgz",
+            "integrity": "sha512-CU+RF9FySljn7HVSkkjiB84hWkvTaI3rtLvF433+jRSBL2hMu3zX5bGhHS8C80SM++h4xy8hBSnUHFQHmRXSBw==",
+            "dev": true,
+            "requires": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "@swc/types": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.6.tgz",
+            "integrity": "sha512-/JLo/l2JsT/LRd80C3HfbmVpxOAJ11FO2RCEslFrgzLltoP9j8XIbsyDcfCt2WWyX+CM96rBoNM+IToAkFOugg==",
+            "dev": true,
+            "requires": {
+                "@swc/counter": "^0.1.3"
             }
         },
         "@types/babel__core": {
@@ -7672,15 +8893,24 @@
             "dev": true
         },
         "@types/node": {
-            "version": "18.8.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.2.tgz",
-            "integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA==",
-            "dev": true
+            "version": "20.12.7",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
+            "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+            "dev": true,
+            "requires": {
+                "undici-types": "~5.26.4"
+            }
         },
         "@types/prettier": {
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
             "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
+            "dev": true
+        },
+        "@types/resolve": {
+            "version": "1.20.2",
+            "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+            "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
             "dev": true
         },
         "@types/stack-utils": {
@@ -7978,6 +9208,12 @@
                 "picomatch": "^2.0.4"
             }
         },
+        "arg": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+            "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+            "dev": true
+        },
         "argparse": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -8206,6 +9442,37 @@
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "dev": true
         },
+        "builtin-modules": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+            "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+            "dev": true
+        },
+        "bunchee": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/bunchee/-/bunchee-5.1.2.tgz",
+            "integrity": "sha512-fOcub+z6CcCesKjVX82+B6wPTzQjtcHjrI1zcAc/acc5PRmI4fNsww7p20VxR8lctaXPrLnbuWeuhtSrZ311/Q==",
+            "dev": true,
+            "requires": {
+                "@rollup/plugin-commonjs": "^25.0.7",
+                "@rollup/plugin-json": "^6.1.0",
+                "@rollup/plugin-node-resolve": "^15.2.3",
+                "@rollup/plugin-replace": "^5.0.5",
+                "@rollup/plugin-wasm": "^6.2.2",
+                "@rollup/pluginutils": "^5.1.0",
+                "@swc/core": "^1.4.8",
+                "@swc/helpers": "^0.5.6",
+                "arg": "^5.0.2",
+                "clean-css": "^5.3.3",
+                "magic-string": "^0.30.8",
+                "pretty-bytes": "^5.6.0",
+                "rollup": "^4.13.0",
+                "rollup-plugin-dts": "^6.1.0",
+                "rollup-plugin-swc3": "^0.11.0",
+                "rollup-preserve-directives": "^1.1.1",
+                "tslib": "^2.6.2"
+            }
+        },
         "callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -8258,6 +9525,15 @@
             "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
             "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
             "dev": true
+        },
+        "clean-css": {
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
+            "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
+            "dev": true,
+            "requires": {
+                "source-map": "~0.6.0"
+            }
         },
         "clean-webpack-plugin": {
             "version": "4.0.0",
@@ -8524,6 +9800,12 @@
             "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
             "dev": true
         },
+        "estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true
+        },
         "events": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -8666,6 +9948,15 @@
             "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
             "dev": true
         },
+        "get-tsconfig": {
+            "version": "4.7.3",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.3.tgz",
+            "integrity": "sha512-ZvkrzoUA0PQZM6fy6+/Hce561s+faD1rsNwhnO5FelNjyy7EMGJ3Rz1AQ8GYDWjhRs/7dBLOEJvhK8MiEJOAFg==",
+            "dev": true,
+            "requires": {
+                "resolve-pkg-maps": "^1.0.0"
+            }
+        },
         "glob": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -8802,6 +10093,15 @@
             "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
             "dev": true
         },
+        "is-builtin-module": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+            "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+            "dev": true,
+            "requires": {
+                "builtin-modules": "^3.3.0"
+            }
+        },
         "is-core-module": {
             "version": "2.10.0",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
@@ -8821,6 +10121,12 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
             "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+            "dev": true
+        },
+        "is-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+            "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
             "dev": true
         },
         "is-number": {
@@ -8860,6 +10166,15 @@
             "dev": true,
             "requires": {
                 "isobject": "^3.0.1"
+            }
+        },
+        "is-reference": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+            "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+            "dev": true,
+            "requires": {
+                "@types/estree": "*"
             }
         },
         "is-stream": {
@@ -10195,6 +11510,15 @@
                 "yallist": "^4.0.0"
             }
         },
+        "magic-string": {
+            "version": "0.30.10",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
+            "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/sourcemap-codec": "^1.4.15"
+            }
+        },
         "make-dir": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -10504,6 +11828,12 @@
             "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
             "dev": true
         },
+        "pretty-bytes": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+            "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+            "dev": true
+        },
         "pretty-format": {
             "version": "28.1.3",
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz",
@@ -10709,6 +12039,12 @@
             "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
             "dev": true
         },
+        "resolve-pkg-maps": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+            "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+            "dev": true
+        },
         "resolve.exports": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz",
@@ -10722,6 +12058,71 @@
             "dev": true,
             "requires": {
                 "glob": "^7.1.3"
+            }
+        },
+        "rollup": {
+            "version": "4.14.3",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.3.tgz",
+            "integrity": "sha512-ag5tTQKYsj1bhrFC9+OEWqb5O6VYgtQDO9hPDBMmIbePwhfSr+ExlcU741t8Dhw5DkPCQf6noz0jb36D6W9/hw==",
+            "dev": true,
+            "requires": {
+                "@rollup/rollup-android-arm-eabi": "4.14.3",
+                "@rollup/rollup-android-arm64": "4.14.3",
+                "@rollup/rollup-darwin-arm64": "4.14.3",
+                "@rollup/rollup-darwin-x64": "4.14.3",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.14.3",
+                "@rollup/rollup-linux-arm-musleabihf": "4.14.3",
+                "@rollup/rollup-linux-arm64-gnu": "4.14.3",
+                "@rollup/rollup-linux-arm64-musl": "4.14.3",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.14.3",
+                "@rollup/rollup-linux-riscv64-gnu": "4.14.3",
+                "@rollup/rollup-linux-s390x-gnu": "4.14.3",
+                "@rollup/rollup-linux-x64-gnu": "4.14.3",
+                "@rollup/rollup-linux-x64-musl": "4.14.3",
+                "@rollup/rollup-win32-arm64-msvc": "4.14.3",
+                "@rollup/rollup-win32-ia32-msvc": "4.14.3",
+                "@rollup/rollup-win32-x64-msvc": "4.14.3",
+                "@types/estree": "1.0.5",
+                "fsevents": "~2.3.2"
+            },
+            "dependencies": {
+                "@types/estree": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+                    "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+                    "dev": true
+                }
+            }
+        },
+        "rollup-plugin-dts": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-6.1.0.tgz",
+            "integrity": "sha512-ijSCPICkRMDKDLBK9torss07+8dl9UpY9z1N/zTeA1cIqdzMlpkV3MOOC7zukyvQfDyxa1s3Dl2+DeiP/G6DOw==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.22.13",
+                "magic-string": "^0.30.4"
+            }
+        },
+        "rollup-plugin-swc3": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-swc3/-/rollup-plugin-swc3-0.11.1.tgz",
+            "integrity": "sha512-6j8kWS6HM63P9pc6O5UtfhZkW9vVmkYfoEmZxR3Nua6KQRDCM3a6RrskqiGeiCnJ9s1W+tAmlVYz80G9yy2/Kg==",
+            "dev": true,
+            "requires": {
+                "@fastify/deepmerge": "^1.3.0",
+                "@rollup/pluginutils": "^5.1.0",
+                "get-tsconfig": "^4.7.3",
+                "rollup-preserve-directives": "^1.1.1"
+            }
+        },
+        "rollup-preserve-directives": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/rollup-preserve-directives/-/rollup-preserve-directives-1.1.1.tgz",
+            "integrity": "sha512-+eQafbuEfDPfxQ9hQPlwaROfin4yiVRxap8hnrvvvcSGoukv1tTiYpAW9mvm3uR8J+fe4xd8FdVd5rz9q7jZ+Q==",
+            "dev": true,
+            "requires": {
+                "magic-string": "^0.30.5"
             }
         },
         "safe-buffer": {
@@ -11192,6 +12593,12 @@
                 }
             }
         },
+        "tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+            "dev": true
+        },
         "type-detect": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -11208,6 +12615,12 @@
             "version": "4.9.4",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
             "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+            "dev": true
+        },
+        "undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
             "dev": true
         },
         "update-browserslist-db": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "xior-auth-refresh",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "xior-auth-refresh",
-            "version": "0.0.4",
+            "version": "0.1.0",
             "license": "MIT",
             "devDependencies": {
                 "@types/jest": "^28.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "xior-auth-refresh",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "xior-auth-refresh",
-            "version": "0.0.3",
+            "version": "0.0.4",
             "license": "MIT",
             "devDependencies": {
                 "@types/jest": "^28.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "xior-auth-refresh",
-    "version": "0.1.1",
+    "version": "0.1.2-alpha.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "xior-auth-refresh",
-            "version": "0.1.1",
+            "version": "0.1.2-alpha.0",
             "license": "MIT",
             "devDependencies": {
                 "@types/jest": "^28.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
-    "name": "axios-auth-refresh",
-    "version": "3.3.6",
+    "name": "@mgoodfellow/xior-auth-refresh",
+    "version": "0.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "axios-auth-refresh",
-            "version": "3.3.6",
+            "name": "@mgoodfellow/xior-auth-refresh",
+            "version": "0.0.1",
             "license": "MIT",
             "devDependencies": {
                 "@types/jest": "^28.1.6",
-                "axios": "^1.2.2",
                 "babel-loader": "^9.1.0",
                 "clean-webpack-plugin": "^4.0.0",
                 "declaration-bundler-webpack-plugin": "^1.0.3",
@@ -23,10 +22,11 @@
                 "ts-loader": "^9.3.1",
                 "typescript": "^4.9.4",
                 "webpack": "^5.73.0",
-                "webpack-cli": "^5.0.1"
+                "webpack-cli": "^5.0.1",
+                "xior": "^0.3.12"
             },
             "peerDependencies": {
-                "axios": ">= 0.18 < 0.19.0 || >= 0.19.1"
+                "xior": "^0.3.12"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -1845,23 +1845,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-            "dev": true
-        },
-        "node_modules/axios": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
-            "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
-            "dev": true,
-            "dependencies": {
-                "follow-redirects": "^1.15.0",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
-            }
-        },
         "node_modules/babel-jest": {
             "version": "28.1.3",
             "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-28.1.3.tgz",
@@ -2281,18 +2264,6 @@
             "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
             "dev": true
         },
-        "node_modules/combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "dev": true,
-            "dependencies": {
-                "delayed-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/commander": {
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -2388,15 +2359,6 @@
             },
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "node_modules/detect-newline": {
@@ -2691,40 +2653,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/follow-redirects": {
-            "version": "1.15.2",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-            "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/form-data": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-            "dev": true,
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/fs.realpath": {
@@ -5454,12 +5382,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-            "dev": true
-        },
         "node_modules/pump": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -6044,6 +5966,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/tiny-lru": {
+            "version": "11.2.6",
+            "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-11.2.6.tgz",
+            "integrity": "sha512-0PU3c9PjMnltZaFo2sGYv/nnJsMjG0Cxx8X6FXHPPGjFyoo1SJDxvUXW1207rdiSxYizf31roo+GrkIByQeZoA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/tmpl": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -6069,6 +6000,15 @@
             },
             "engines": {
                 "node": ">=8.0"
+            }
+        },
+        "node_modules/ts-deepmerge": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-7.0.0.tgz",
+            "integrity": "sha512-WZ/iAJrKDhdINv1WG6KZIGHrZDar6VfhftG1QJFpVbOYZMYJLJOvZOo1amictRXVdBXZIgBHKswMTXzElngprA==",
+            "dev": true,
+            "engines": {
+                "node": ">=14.13.1"
             }
         },
         "node_modules/ts-jest": {
@@ -6567,6 +6507,16 @@
             },
             "engines": {
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+            }
+        },
+        "node_modules/xior": {
+            "version": "0.3.12",
+            "resolved": "https://registry.npmjs.org/xior/-/xior-0.3.12.tgz",
+            "integrity": "sha512-jugPO7n8HxUGEWRP8evf1iZZblMeY3rJ/ym6epAzqUEiRHnaHAxBS8gu/Pm1q/SxeYDy69N4S89vZoplCS0xpQ==",
+            "dev": true,
+            "dependencies": {
+                "tiny-lru": "^11.2.5",
+                "ts-deepmerge": "^7.0.0"
             }
         },
         "node_modules/y18n": {
@@ -8064,23 +8014,6 @@
             "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
             "dev": true
         },
-        "asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-            "dev": true
-        },
-        "axios": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
-            "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
-            "dev": true,
-            "requires": {
-                "follow-redirects": "^1.15.0",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
-            }
-        },
         "babel-jest": {
             "version": "28.1.3",
             "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-28.1.3.tgz",
@@ -8390,15 +8323,6 @@
             "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
             "dev": true
         },
-        "combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "dev": true,
-            "requires": {
-                "delayed-stream": "~1.0.0"
-            }
-        },
         "commander": {
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -8478,12 +8402,6 @@
                 "pify": "^4.0.1",
                 "rimraf": "^2.6.3"
             }
-        },
-        "delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-            "dev": true
         },
         "detect-newline": {
             "version": "3.1.0",
@@ -8703,23 +8621,6 @@
             "requires": {
                 "locate-path": "^5.0.0",
                 "path-exists": "^4.0.0"
-            }
-        },
-        "follow-redirects": {
-            "version": "1.15.2",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-            "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-            "dev": true
-        },
-        "form-data": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-            "dev": true,
-            "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
             }
         },
         "fs.realpath": {
@@ -10730,12 +10631,6 @@
                 "sisteransi": "^1.0.5"
             }
         },
-        "proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-            "dev": true
-        },
         "pump": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -11165,6 +11060,12 @@
                 "minimatch": "^3.0.4"
             }
         },
+        "tiny-lru": {
+            "version": "11.2.6",
+            "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-11.2.6.tgz",
+            "integrity": "sha512-0PU3c9PjMnltZaFo2sGYv/nnJsMjG0Cxx8X6FXHPPGjFyoo1SJDxvUXW1207rdiSxYizf31roo+GrkIByQeZoA==",
+            "dev": true
+        },
         "tmpl": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -11185,6 +11086,12 @@
             "requires": {
                 "is-number": "^7.0.0"
             }
+        },
+        "ts-deepmerge": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-7.0.0.tgz",
+            "integrity": "sha512-WZ/iAJrKDhdINv1WG6KZIGHrZDar6VfhftG1QJFpVbOYZMYJLJOvZOo1amictRXVdBXZIgBHKswMTXzElngprA==",
+            "dev": true
         },
         "ts-jest": {
             "version": "28.0.8",
@@ -11508,6 +11415,16 @@
             "requires": {
                 "imurmurhash": "^0.1.4",
                 "signal-exit": "^3.0.7"
+            }
+        },
+        "xior": {
+            "version": "0.3.12",
+            "resolved": "https://registry.npmjs.org/xior/-/xior-0.3.12.tgz",
+            "integrity": "sha512-jugPO7n8HxUGEWRP8evf1iZZblMeY3rJ/ym6epAzqUEiRHnaHAxBS8gu/Pm1q/SxeYDy69N4S89vZoplCS0xpQ==",
+            "dev": true,
+            "requires": {
+                "tiny-lru": "^11.2.5",
+                "ts-deepmerge": "^7.0.0"
             }
         },
         "y18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "xior-auth-refresh",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "xior-auth-refresh",
-            "version": "0.1.0",
+            "version": "0.1.1",
             "license": "MIT",
             "devDependencies": {
                 "@types/jest": "^28.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mgoodfellow/xior-auth-refresh",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@mgoodfellow/xior-auth-refresh",
-            "version": "0.0.2",
+            "version": "0.0.3",
             "license": "MIT",
             "devDependencies": {
                 "@types/jest": "^28.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xior-auth-refresh",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "Xior plugin which makes it very easy to automatically refresh the authorization tokens of your clients",
     "keywords": [
         "xior",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xior-auth-refresh",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Xior plugin which makes it very easy to automatically refresh the authorization tokens of your clients",
     "keywords": [
         "xior",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-    "name": "axios-auth-refresh",
-    "version": "3.3.6",
-    "description": "Axios plugin which makes it very easy to automatically refresh the authorization tokens of your clients",
+    "name": "@mgoodfellow/xior-auth-refresh",
+    "version": "0.0.1",
+    "description": "Xior plugin which makes it very easy to automatically refresh the authorization tokens of your clients",
     "keywords": [
-        "axios",
+        "xior",
         "authentication",
         "authorization",
         "refresh token",
@@ -11,10 +11,20 @@
         "interceptor",
         "auto refresh"
     ],
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mgoodfellow/xior-auth-refresh.git"
+    },
+    "publishConfig": {
+        "registry": "https://npm.pkg.github.com"
+    },
     "main": "dist/index.min.js",
     "types": "dist/index.d.ts",
-    "repository": "https://github.com/Flyrell/axios-auth-refresh",
     "author": "Dawid Zbiński <dawid@zbinski.eu>",
+    "contributors": [
+        "Dawid Zbiński <dawid@zbinski.eu>",
+        "Mike Goodfellow"
+    ],
     "license": "MIT",
     "private": false,
     "scripts": {
@@ -28,11 +38,11 @@
         "prepare": "husky install"
     },
     "peerDependencies": {
-        "axios": ">= 0.18 < 0.19.0 || >= 0.19.1"
+        "xior": "^0.3.12"
     },
     "devDependencies": {
         "@types/jest": "^28.1.6",
-        "axios": "^1.2.2",
+        "xior": "^0.3.12",
         "babel-loader": "^9.1.0",
         "clean-webpack-plugin": "^4.0.0",
         "declaration-bundler-webpack-plugin": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@mgoodfellow/xior-auth-refresh",
+    "name": "xior-auth-refresh",
     "version": "0.0.1",
     "description": "Xior plugin which makes it very easy to automatically refresh the authorization tokens of your clients",
     "keywords": [
@@ -13,17 +13,18 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/mgoodfellow/xior-auth-refresh.git"
+        "url": "git+https://github.com/Audiu/xior-auth-refresh.git"
     },
-    "publishConfig": {
-        "registry": "https://npm.pkg.github.com"
+    "bugs": {
+        "url": "https://github.com/Audiu/xior-auth-refresh/issues"
     },
+    "homepage": "https://github.com/Audiu/xior-auth-refresh#readme",
     "main": "dist/index.min.js",
     "types": "dist/index.d.ts",
     "author": "Dawid Zbiński <dawid@zbinski.eu>",
     "contributors": [
         "Dawid Zbiński <dawid@zbinski.eu>",
-        "Mike Goodfellow"
+        "Mike Goodfellow <mg.npm.email@gmail.com>"
     ],
     "license": "MIT",
     "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xior-auth-refresh",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Xior plugin which makes it very easy to automatically refresh the authorization tokens of your clients",
     "keywords": [
         "xior",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xior-auth-refresh",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "description": "Xior plugin which makes it very easy to automatically refresh the authorization tokens of your clients",
     "keywords": [
         "xior",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xior-auth-refresh",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "Xior plugin which makes it very easy to automatically refresh the authorization tokens of your clients",
     "keywords": [
         "xior",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xior-auth-refresh",
-    "version": "0.1.1",
+    "version": "0.1.2-alpha.0",
     "description": "Xior plugin which makes it very easy to automatically refresh the authorization tokens of your clients",
     "keywords": [
         "xior",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,17 @@
         "url": "https://github.com/Audiu/xior-auth-refresh/issues"
     },
     "homepage": "https://github.com/Audiu/xior-auth-refresh#readme",
-    "main": "dist/index.min.js",
-    "types": "dist/index.d.ts",
+    "main": "./dist/index.cjs",
+    "types": "./dist/index.d.ts",
+    "require": "./dist/index.cjs",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "require": "./dist/index.cjs",
+            "import": "./dist/index.mjs",
+            "module": "./dist/index.esm.js"
+        }
+    },
     "author": "Dawid Zbiński <dawid@zbinski.eu>",
     "contributors": [
         "Dawid Zbiński <dawid@zbinski.eu>",
@@ -30,7 +39,8 @@
     "private": false,
     "scripts": {
         "dev": "webpack --mode development",
-        "build": "webpack --mode production",
+        "build": "bunchee -m",
+        "build:umd": "webpack --mode production",
         "typescript": "tsc --noEmit",
         "test": "jest",
         "test:coverage": "jest --coverage",
@@ -42,6 +52,7 @@
         "xior": "^0.3.12"
     },
     "devDependencies": {
+        "bunchee": "^5.1.2",
         "@types/jest": "^28.1.6",
         "xior": "^0.3.12",
         "babel-loader": "^9.1.0",

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -278,9 +278,7 @@ describe('Requests interceptor', () => {
                 cache
             );
             await instance.get('http://example.com').then(() => expect(refreshed).toBe(1));
-            await instance
-                .get('http://example.com', <XiorAuthRefreshRequestConfig>{ skipAuthRefresh: true })
-                .then(() => expect(refreshed).toBe(1));
+            await instance.get('http://example.com', { skipAuthRefresh: true }).then(() => expect(refreshed).toBe(1));
         } catch (e) {
             expect(e).toBeFalsy();
         }

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
-import { AxiosAuthRefreshCache, AxiosAuthRefreshRequestConfig } from '../model';
-import axios, { AxiosRequestConfig, AxiosStatic } from 'axios';
-import createAuthRefreshInterceptor, { AxiosAuthRefreshOptions } from '../index';
+import { XiorAuthRefreshCache, XiorAuthRefreshRequestConfig } from '../model';
+import xior, { XiorRequestConfig } from 'xior';
+import createAuthRefreshInterceptor, { XiorAuthRefreshOptions } from '../index';
 import {
     unsetCache,
     mergeOptions,
@@ -11,7 +11,7 @@ import {
     createRequestQueueInterceptor,
 } from '../utils';
 
-const mockedAxios: () => AxiosStatic | any = () => {
+const mockedXior: () => any = () => {
     const bag = {
         request: [],
         response: [],
@@ -58,26 +58,26 @@ const sleep = (ms) => {
 
 describe('Merges configs', () => {
     it('source and target are the same', () => {
-        const source: AxiosAuthRefreshOptions = { statusCodes: [204] };
-        const target: AxiosAuthRefreshOptions = { statusCodes: [204] };
+        const source: XiorAuthRefreshOptions = { statusCodes: [204] };
+        const target: XiorAuthRefreshOptions = { statusCodes: [204] };
         expect(mergeOptions(target, source)).toEqual({ statusCodes: [204] });
     });
 
     it('source is different than the target', () => {
-        const source: AxiosAuthRefreshOptions = { statusCodes: [302] };
-        const target: AxiosAuthRefreshOptions = { statusCodes: [204] };
+        const source: XiorAuthRefreshOptions = { statusCodes: [302] };
+        const target: XiorAuthRefreshOptions = { statusCodes: [204] };
         expect(mergeOptions(target, source)).toEqual({ statusCodes: [302] });
     });
 
     it('source is empty', () => {
-        const source: AxiosAuthRefreshOptions = {};
-        const target: AxiosAuthRefreshOptions = { statusCodes: [204] };
+        const source: XiorAuthRefreshOptions = {};
+        const target: XiorAuthRefreshOptions = { statusCodes: [204] };
         expect(mergeOptions(target, source)).toEqual({ statusCodes: [204] });
     });
 });
 
 describe('Determines if the response should be intercepted', () => {
-    let cache: AxiosAuthRefreshCache = undefined;
+    let cache: XiorAuthRefreshCache = undefined;
     beforeEach(() => {
         cache = {
             skipInstances: [],
@@ -89,27 +89,27 @@ describe('Determines if the response should be intercepted', () => {
     const options = { statusCodes: [401] };
 
     it('no error object provided', () => {
-        expect(shouldInterceptError(undefined, options, axios, cache)).toBeFalsy();
+        expect(shouldInterceptError(undefined, options, xior, cache)).toBeFalsy();
     });
 
     it('no response inside error object', () => {
-        expect(shouldInterceptError({}, options, axios, cache)).toBeFalsy();
+        expect(shouldInterceptError({}, options, xior, cache)).toBeFalsy();
     });
 
     it('no status in error.response object', () => {
-        expect(shouldInterceptError({ response: {} }, options, axios, cache)).toBeFalsy();
+        expect(shouldInterceptError({ response: {} }, options, xior, cache)).toBeFalsy();
     });
 
     it('error does not include the response status', () => {
-        expect(shouldInterceptError({ response: { status: 403 } }, options, axios, cache)).toBeFalsy();
+        expect(shouldInterceptError({ response: { status: 403 } }, options, xior, cache)).toBeFalsy();
     });
 
     it('error includes the response status', () => {
-        expect(shouldInterceptError({ response: { status: 401 } }, options, axios, cache)).toBeTruthy();
+        expect(shouldInterceptError({ response: { status: 401 } }, options, xior, cache)).toBeTruthy();
     });
 
     it('error has response status specified as a string', () => {
-        expect(shouldInterceptError({ response: { status: '401' } }, options, axios, cache)).toBeTruthy();
+        expect(shouldInterceptError({ response: { status: '401' } }, options, xior, cache)).toBeTruthy();
     });
 
     it('when skipAuthRefresh flag is set ot true', () => {
@@ -117,7 +117,7 @@ describe('Determines if the response should be intercepted', () => {
             response: { status: 401 },
             config: { skipAuthRefresh: true },
         };
-        expect(shouldInterceptError(error, options, axios, cache)).toBeFalsy();
+        expect(shouldInterceptError(error, options, xior, cache)).toBeFalsy();
     });
 
     it('when skipAuthRefresh flag is set to false', () => {
@@ -125,23 +125,23 @@ describe('Determines if the response should be intercepted', () => {
             response: { status: 401 },
             config: { skipAuthRefresh: false },
         };
-        expect(shouldInterceptError(error, options, axios, cache)).toBeTruthy();
+        expect(shouldInterceptError(error, options, xior, cache)).toBeTruthy();
     });
 
     it('when pauseInstanceWhileRefreshing flag is not provided', () => {
         const error = {
             response: { status: 401 },
         };
-        expect(shouldInterceptError(error, options, axios, cache)).toBeTruthy();
+        expect(shouldInterceptError(error, options, xior, cache)).toBeTruthy();
     });
 
     it('when pauseInstanceWhileRefreshing flag is set to true', () => {
         const error = {
             response: { status: 401 },
         };
-        const newCache = { ...cache, skipInstances: [axios] };
+        const newCache = { ...cache, skipInstances: [xior] };
         const newOptions = { ...options, pauseInstanceWhileRefreshing: true };
-        expect(shouldInterceptError(error, newOptions, axios, newCache)).toBeFalsy();
+        expect(shouldInterceptError(error, newOptions, xior, newCache)).toBeFalsy();
     });
 
     it('when pauseInstanceWhileRefreshing flag is set to false', () => {
@@ -149,28 +149,28 @@ describe('Determines if the response should be intercepted', () => {
             response: { status: 401 },
         };
         const newOptions = { ...options, pauseInstanceWhileRefreshing: false };
-        expect(shouldInterceptError(error, newOptions, axios, cache)).toBeTruthy();
+        expect(shouldInterceptError(error, newOptions, xior, cache)).toBeTruthy();
     });
 
     it('when shouldRefresh return true', () => {
         const error = {
             response: { status: 401 },
         };
-        const newOptions: AxiosAuthRefreshOptions = { ...options, shouldRefresh: () => true };
-        expect(shouldInterceptError(error, newOptions, axios, cache)).toBeTruthy();
+        const newOptions: XiorAuthRefreshOptions = { ...options, shouldRefresh: () => true };
+        expect(shouldInterceptError(error, newOptions, xior, cache)).toBeTruthy();
     });
 
     it('when shouldRefresh return false', () => {
         const error = {
             response: { status: 401 },
         };
-        const newOptions: AxiosAuthRefreshOptions = { ...options, shouldRefresh: () => false };
-        expect(shouldInterceptError(error, newOptions, axios, cache)).toBeFalsy();
+        const newOptions: XiorAuthRefreshOptions = { ...options, shouldRefresh: () => false };
+        expect(shouldInterceptError(error, newOptions, xior, cache)).toBeFalsy();
     });
 });
 
 describe('Creates refresh call', () => {
-    let cache: AxiosAuthRefreshCache = undefined;
+    let cache: XiorAuthRefreshCache = undefined;
     beforeEach(() => {
         cache = {
             skipInstances: [],
@@ -220,7 +220,7 @@ describe('Creates refresh call', () => {
 });
 
 describe('Requests interceptor', () => {
-    let cache: AxiosAuthRefreshCache = undefined;
+    let cache: XiorAuthRefreshCache = undefined;
     beforeEach(() => {
         cache = {
             skipInstances: [],
@@ -230,7 +230,7 @@ describe('Requests interceptor', () => {
     });
 
     it('is created', () => {
-        const mock = mockedAxios();
+        const mock = mockedXior();
         createRefreshCall({}, () => Promise.resolve(), cache);
         const result1 = createRequestQueueInterceptor(mock, cache, {});
         expect(mock.interceptors.has('request', result1)).toBeTruthy();
@@ -239,15 +239,15 @@ describe('Requests interceptor', () => {
 
     it('is created only once', () => {
         createRefreshCall({}, () => Promise.resolve(), cache);
-        const result1 = createRequestQueueInterceptor(axios.create(), cache, {});
-        const result2 = createRequestQueueInterceptor(axios.create(), cache, {});
+        const result1 = createRequestQueueInterceptor(xior.create(), cache, {});
+        const result2 = createRequestQueueInterceptor(xior.create(), cache, {});
         expect(result1).toBe(result2);
     });
 
     it('intercepts the requests', async () => {
         try {
             let refreshed = 0;
-            const instance = axios.create();
+            const instance = xior.create();
             createRequestQueueInterceptor(instance, cache, {});
             createRefreshCall(
                 {},
@@ -267,7 +267,7 @@ describe('Requests interceptor', () => {
     it("doesn't intercept skipped request", async () => {
         try {
             let refreshed = 0;
-            const instance = axios.create();
+            const instance = xior.create();
             createRequestQueueInterceptor(instance, cache, {});
             createRefreshCall(
                 {},
@@ -279,7 +279,7 @@ describe('Requests interceptor', () => {
             );
             await instance.get('http://example.com').then(() => expect(refreshed).toBe(1));
             await instance
-                .get('http://example.com', <AxiosAuthRefreshRequestConfig>{ skipAuthRefresh: true })
+                .get('http://example.com', <XiorAuthRefreshRequestConfig>{ skipAuthRefresh: true })
                 .then(() => expect(refreshed).toBe(1));
         } catch (e) {
             expect(e).toBeFalsy();
@@ -290,7 +290,7 @@ describe('Requests interceptor', () => {
         try {
             let passed = 0,
                 caught = 0;
-            const instance = axios.create();
+            const instance = xior.create();
             createRequestQueueInterceptor(instance, cache, {});
             createRefreshCall(
                 {},
@@ -315,21 +315,21 @@ describe('Requests interceptor', () => {
         }
     });
 
-    it('uses the correct instance of axios to retry requests', () => {
-        const instance = axios.create();
+    it('uses the correct instance of xior to retry requests', () => {
+        const instance = xior.create();
         const options = mergeOptions(defaultOptions, {});
         const result = getRetryInstance(instance, options);
         expect(result).toBe(instance);
 
-        const retryInstance = axios.create();
+        const retryInstance = xior.create();
         const optionsWithRetryInstance = mergeOptions(defaultOptions, { retryInstance });
         const resultWithRetryInstance = getRetryInstance(instance, optionsWithRetryInstance);
         expect(resultWithRetryInstance).toBe(retryInstance);
     });
 
     it('calls the onRetry callback before retrying the request', async () => {
-        const instance = axios.create();
-        const onRetry = jest.fn((requestConfig: AxiosRequestConfig) => requestConfig);
+        const instance = xior.create();
+        const onRetry = jest.fn((requestConfig: XiorRequestConfig) => requestConfig);
         createRequestQueueInterceptor(instance, cache, { onRetry });
         createRefreshCall(
             {},
@@ -346,8 +346,8 @@ describe('Requests interceptor', () => {
 
 describe('Response interceptor', () => {
     it('uses the request interceptor to call the onRetry callback before retrying the request', async () => {
-        const instance = axios.create();
-        const onRetry = jest.fn((requestConfig: AxiosRequestConfig) => {
+        const instance = xior.create();
+        const onRetry = jest.fn((requestConfig: XiorRequestConfig) => {
             // modify the url to one that will respond with status code 200
             return {
                 ...requestConfig,
@@ -362,8 +362,8 @@ describe('Response interceptor', () => {
     });
 
     it('uses the request interceptor to call the onRetry callback before retrying all the requests', async () => {
-        const instance = axios.create();
-        const onRetry = jest.fn((requestConfig: AxiosRequestConfig) => {
+        const instance = xior.create();
+        const onRetry = jest.fn((requestConfig: XiorRequestConfig) => {
             // modify the url to one that will respond with status code 200
             return {
                 ...requestConfig,
@@ -387,49 +387,49 @@ describe('Response interceptor', () => {
 
 describe('Creates the overall interceptor correctly', () => {
     it('throws error when no function provided', () => {
-        expect(() => createAuthRefreshInterceptor(axios, null)).toThrow();
+        expect(() => createAuthRefreshInterceptor(xior, null)).toThrow();
     });
 
-    it('returns interceptor id', () => {
-        const id = createAuthRefreshInterceptor(axios, () => Promise.resolve());
-        expect(typeof id).toBe('number');
-        expect(id).toBeGreaterThan(-1);
-    });
+    // it('returns interceptor id', () => {
+    //     const id = createAuthRefreshInterceptor(xior, () => Promise.resolve());
+    //     expect(typeof id).toBe('number');
+    //     expect(id).toBeGreaterThan(-1);
+    // });
 
-    it('does not change the interceptors queue', async () => {
-        try {
-            const instance = axios.create();
-            const id = createAuthRefreshInterceptor(axios, () => instance.get('https://httpstat.us/200'));
-            const id2 = instance.interceptors.response.use(
-                (req) => req,
-                (error) => Promise.reject(error)
-            );
-            const interceptor1 = instance.interceptors.response['handlers'][id];
-            const interceptor2 = instance.interceptors.response['handlers'][id2];
-            try {
-                await instance.get('https://httpstat.us/401');
-            } catch (e) {
-                // Ignore error as it's 401 all over again
-            }
-            const interceptor1__after = instance.interceptors.response['handlers'][id];
-            const interceptor2__after = instance.interceptors.response['handlers'][id2];
-            expect(interceptor1).toBe(interceptor1__after);
-            expect(interceptor2).toBe(interceptor2__after);
-        } catch (e) {
-            return await Promise.reject();
-        }
-    });
+    // it('does not change the interceptors queue', async () => {
+    //     try {
+    //         const instance = xior.create();
+    //         const id = createAuthRefreshInterceptor(xior, () => instance.get('https://httpstat.us/200'));
+    //         const id2 = instance.interceptors.response.use(
+    //             (req) => req,
+    //             (error) => Promise.reject(error)
+    //         );
+    //         const interceptor1 = instance.interceptors.response['handlers'][id];
+    //         const interceptor2 = instance.interceptors.response['handlers'][id2];
+    //         try {
+    //             await instance.get('https://httpstat.us/401');
+    //         } catch (e) {
+    //             // Ignore error as it's 401 all over again
+    //         }
+    //         const interceptor1__after = instance.interceptors.response['handlers'][id];
+    //         const interceptor2__after = instance.interceptors.response['handlers'][id2];
+    //         expect(interceptor1).toBe(interceptor1__after);
+    //         expect(interceptor2).toBe(interceptor2__after);
+    //     } catch (e) {
+    //         return await Promise.reject();
+    //     }
+    // });
 });
 
 describe('State is cleared', () => {
-    const cache: AxiosAuthRefreshCache = {
+    const cache: XiorAuthRefreshCache = {
         skipInstances: [],
         refreshCall: undefined,
         requestQueueInterceptorId: undefined,
     };
 
     it('after refreshing call succeeds/fails', () => {
-        const instance = mockedAxios();
+        const instance = mockedXior();
         cache.requestQueueInterceptorId = instance.interceptors.request.use(() => undefined);
         cache.skipInstances.push(instance);
         expect(instance.interceptors.has('request', cache.requestQueueInterceptorId)).toBeTruthy();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { AxiosInstance, AxiosResponse, AxiosPromise } from 'axios';
-import { AxiosAuthRefreshOptions, AxiosAuthRefreshCache } from './model';
+import { XiorInstance, XiorResponse } from 'xior';
+import { XiorAuthRefreshOptions, XiorAuthRefreshCache } from './model';
 import {
     unsetCache,
     mergeOptions,
@@ -11,7 +11,7 @@ import {
     createRequestQueueInterceptor,
 } from './utils';
 
-export { AxiosAuthRefreshOptions, AxiosAuthRefreshRequestConfig } from './model';
+export { XiorAuthRefreshOptions, XiorAuthRefreshRequestConfig } from './model';
 
 /**
  * Creates an authentication refresh interceptor that binds to any error response.
@@ -23,28 +23,28 @@ export { AxiosAuthRefreshOptions, AxiosAuthRefreshRequestConfig } from './model'
  * turned off, but use it with caution as you need to mark the requests with `skipAuthRefresh` flag yourself in order to
  * not run into interceptors loop.
  *
- * @param {AxiosInstance} instance - Axios HTTP client instance
- * @param {(error: any) => Promise<AxiosPromise>} refreshAuthCall - refresh token call which must return a Promise
- * @param {AxiosAuthRefreshOptions} options - options for the interceptor @see defaultOptions
- * @return {number} - interceptor id (in case you want to eject it manually)
+ * @param {XiorInstance} instance - Xior HTTP client instance
+ * @param {(error: any) => Promise<any>} refreshAuthCall - refresh token call which must return a Promise
+ * @param {XiorAuthRefreshOptions} options - options for the interceptor @see defaultOptions
+ * @return {func} - Anonymous interceptor function
  */
 export default function createAuthRefreshInterceptor(
-    instance: AxiosInstance,
+    instance: XiorInstance,
     refreshAuthCall: (error: any) => Promise<any>,
-    options: AxiosAuthRefreshOptions = {}
-): number {
+    options: XiorAuthRefreshOptions = {}
+): any {
     if (typeof refreshAuthCall !== 'function') {
-        throw new Error('axios-auth-refresh requires `refreshAuthCall` to be a function that returns a promise.');
+        throw new Error('xior-auth-refresh requires `refreshAuthCall` to be a function that returns a promise.');
     }
 
-    const cache: AxiosAuthRefreshCache = {
+    const cache: XiorAuthRefreshCache = {
         skipInstances: [],
         refreshCall: undefined,
         requestQueueInterceptorId: undefined,
     };
 
     return instance.interceptors.response.use(
-        (response: AxiosResponse) => response,
+        (response: any) => response,
         (error: any) => {
             options = mergeOptions(defaultOptions, options);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ declare module 'xior' {
  */
 export default function createAuthRefreshInterceptor(
     instance: XiorInstance,
-    refreshAuthCall: (error: XiorError) => Promise<XiorResponse> | Promise<void>,
+    refreshAuthCall: (error: XiorError) => Promise<void | XiorResponse<any>>,
     options: XiorAuthRefreshOptions = {}
 ): any {
     if (typeof refreshAuthCall !== 'function') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,12 +13,6 @@ import {
 
 export { XiorAuthRefreshOptions, XiorAuthRefreshRequestConfig } from './model';
 
-export declare module xior {
-    interface XiorRequestConfig {
-        skipAuthRefresh?: boolean;
-    }
-}
-
 /**
  * Creates an authentication refresh interceptor that binds to any error response.
  * If the response status code is one of the options.statusCodes, interceptor calls the refreshAuthCall

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import {
 
 export { XiorAuthRefreshOptions, XiorAuthRefreshRequestConfig } from './model';
 
-declare module 'xior' {
+export declare module xior {
     interface XiorRequestConfig {
         skipAuthRefresh?: boolean;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,12 @@ import {
 
 export { XiorAuthRefreshOptions, XiorAuthRefreshRequestConfig } from './model';
 
+declare module 'xior' {
+    interface XiorRequestConfig {
+        skipAuthRefresh?: boolean;
+    }
+}
+
 /**
  * Creates an authentication refresh interceptor that binds to any error response.
  * If the response status code is one of the options.statusCodes, interceptor calls the refreshAuthCall
@@ -30,7 +36,7 @@ export { XiorAuthRefreshOptions, XiorAuthRefreshRequestConfig } from './model';
  */
 export default function createAuthRefreshInterceptor(
     instance: XiorInstance,
-    refreshAuthCall: (error: any) => Promise<any>,
+    refreshAuthCall: (error: any) => Promise<XiorResponse> | Promise<void>,
     options: XiorAuthRefreshOptions = {}
 ): any {
     if (typeof refreshAuthCall !== 'function') {

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,17 +1,17 @@
-import { AxiosError, AxiosInstance, AxiosRequestConfig } from 'axios';
+import { XiorError, XiorInstance, XiorRequestConfig } from 'xior';
 
-export interface AxiosAuthRefreshOptions {
+export interface XiorAuthRefreshOptions {
     statusCodes?: Array<number>;
     /**
      * Determine whether to refresh, if "shouldRefresh" is configured, The "statusCodes" logic will be ignored
-     * @param error AxiosError
+     * @param error XiorError
      * @returns boolean
      */
-    shouldRefresh?(error: AxiosError): boolean;
-    retryInstance?: AxiosInstance;
+    shouldRefresh?(error: XiorError): boolean;
+    retryInstance?: XiorInstance;
     interceptNetworkError?: boolean;
     pauseInstanceWhileRefreshing?: boolean;
-    onRetry?: (requestConfig: AxiosRequestConfig) => AxiosRequestConfig | Promise<AxiosRequestConfig>;
+    onRetry?: (requestConfig: XiorRequestConfig) => XiorRequestConfig | Promise<XiorRequestConfig>;
 
     /**
      * @deprecated
@@ -21,12 +21,12 @@ export interface AxiosAuthRefreshOptions {
     skipWhileRefreshing?: boolean;
 }
 
-export interface AxiosAuthRefreshCache {
-    skipInstances: AxiosInstance[];
+export interface XiorAuthRefreshCache {
+    skipInstances: XiorInstance[];
     refreshCall: Promise<any> | undefined;
-    requestQueueInterceptorId: number | undefined;
+    requestQueueInterceptorId: any;
 }
 
-export interface AxiosAuthRefreshRequestConfig extends AxiosRequestConfig {
+export interface XiorAuthRefreshRequestConfig extends XiorRequestConfig {
     skipAuthRefresh?: boolean;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,5 @@
-import xior, { XiorInstance, XiorRequestConfig } from 'xior';
+import { XiorInstance } from 'xior';
 import { XiorAuthRefreshOptions, XiorAuthRefreshCache } from './model';
-
-export interface CustomXiorRequestConfig extends XiorRequestConfig {
-    skipAuthRefresh?: boolean;
-}
 
 export const defaultOptions: XiorAuthRefreshOptions = {
     statusCodes: [401],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,12 +5,12 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 module.exports = {
     devtool: 'hidden-source-map',
     entry: './src/index.ts',
-    externals: ['axios'],
+    externals: ['xior'],
     output: {
         path: path.resolve(__dirname, 'dist'),
         filename: 'index.min.js',
         library: {
-            name: 'axios-auth-refresh',
+            name: 'xior-auth-refresh',
             type: 'umd',
         },
         globalObject: 'this',


### PR DESCRIPTION
See related issue: https://github.com/suhaotian/xior/issues/15

At the moment, rejecting the promise stops other reject handlers firing in later response interceptors.

This is a temporary patch to deal with this case:
* We don't reject if we aren't running
* We reject when we have successfully run the refresh to stop other reject handlers running

Known issues:
* Later response interceptors fulfill handlers won't run - but in the current version of xior they aren't running anyway